### PR TITLE
Add space

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,7 +60,7 @@
     <section id='abstract'>
          <p>
             This specification defines the Mathematical Markup Language, or
-            <a id="td-mathml"></a>MathML. MathML is a markup language
+            <a id="td-mathml"></a> MathML. MathML is a markup language
             for describing mathematical notation and capturing
             both its structure and content. The goal of MathML is to enable
             mathematics to be served, received, and processed on the World Wide


### PR DESCRIPTION
This renders as This specification defines the Mathematical Markup Language, or HTML StandardMathML. I think it would read better with a space in between Standard and MathML.