### PR TITLE
compressed display of authors and WG members

### DIFF
--- a/src/contributors.html
+++ b/src/contributors.html
@@ -19,94 +19,66 @@
 
   <p>Participants in the Working Group responsible for MathML 3.0 have been:
   </p>
-  <dl>
 
-   <dt>Ron Ausbrooks</dt>
-   <dd>Mackichan Software, Las Cruces NM, USA</dd>
+  <blockquote>
 
-   <dt>Laurent Bernardin</dt>
-   <dd>Waterloo Maple, Inc., Waterloo ON, CAN</dd>
+   <span title="Mackichan Software, Las Cruces NM, USA">Ron Ausbrooks</span>,
 
-   <dt>Pierre-Yves Bertholet</dt>
-   <dd>MITRE Corporation, McLean VA, USA</dd>
+   <span title="Waterloo Maple, Inc., Waterloo ON, CAN">Laurent Bernardin</span>,
 
-   <dt>Bert Bos</dt>
-   <dd>W3C, Sophia-Antipolis, FRA</dd>
+   <span title="MITRE Corporation, McLean VA, USA">Pierre-Yves Bertholet</span>,
 
-   <dt>Mike Brenner</dt>
-   <dd>MITRE Corporation, Bedford MA, USA</dd>
+   <span title="W3C, Sophia-Antipolis, FRA">Bert Bos</span>,
 
-   <dt>Olga Caprotti</dt>
-   <dd>University of Helsinki, Helsinki, FI</dd>
+   <span title="MITRE Corporation, Bedford MA, USA">Mike Brenner</span>,
 
-   <dt>David Carlisle</dt>
-   <dd>NAG Ltd., Oxford, UK</dd>
+   <span title="University of Helsinki, Helsinki, FI">Olga Caprotti</span>,
 
-   <dt>Giorgi Chavchanidze</dt>
-   <dd>Opera Software, Oslo, NO</dd>
+   <span title="NAG Ltd., Oxford, UK">David Carlisle</span>,
 
-   <dt>Ananth Coorg</dt>
-   <dd>The Boeing Company, Seattle WA, USA</dd>
+   <span title="Opera Software, Oslo, NO">Giorgi Chavchanidze</span>,
 
-   <dt>St&#xe9;phane Dalmas</dt>
-   <dd>INRIA, Sophia Antipolis, FRA</dd>
+   <span title="The Boeing Company, Seattle WA, USA">Ananth Coorg</span>,
 
-   <dt>Stan Devitt</dt>
-   <dd>Agfa-Gevaert N. V., Trier, GER</dd>
+   <span title="INRIA, Sophia Antipolis, FRA">St&#xe9;phane Dalmas</span>,
 
-   <dt>Sam Dooley</dt>
-   <dd>Integre Technical Publishing Co., Inc., Albuquerque NM, USA</dd>
+   <span title="Agfa-Gevaert N. V., Trier, GER">Stan Devitt</span>,
 
-   <dt>Margaret Hinchcliffe</dt>
-   <dd>Waterloo Maple, Inc., Waterloo ON, CAN</dd>
+   <span title="Integre Technical Publishing Co., Inc., Albuquerque NM, USA">Sam Dooley</span>,
 
-   <dt>Patrick Ion</dt>
-   <dd>W3C Invited Experts:Mathematical Reviews (American Mathematical
-   Society), Ann Arbor MI, USA</dd>
+   <span title="Waterloo Maple, Inc., Waterloo ON, CAN">Margaret Hinchcliffe</span>,
 
-   <dt>Michael Kohlhase</dt>
-   <dd>German Research Center for Artificial Intelligence (DFKI) Gmbh, GER</dd>
+   <span title="W3C Invited Experts:Mathematical Reviews (American Mathematical Society), Ann Arbor MI, USA">Patrick Ion</span>,
 
-   <dt>Azzeddine Lazrek</dt>
-   <dd>W3C Invited Experts: University of Marrakesh, Morocco</dd>
+   <span title="German Research Center for Artificial Intelligence (DFKI) Gmbh, GER">Michael Kohlhase</span>,
 
-   <dt>Dennis Leas</dt>
-   <dd>DAISY Consortium</dd>
+   <span title="W3C Invited Experts: University of Marrakesh, Morocco">Azzeddine Lazrek</span>,
 
-   <dt>Paul Libbrecht</dt>
-   <dd>German Research Center for Artificial Intelligence (DFKI) Gmbh, GER</dd>
+   <span title="DAISY Consortium">Dennis Leas</span>,
 
-   <dt>Manolis Mavrikis</dt>
-   <dd>University of Edinburgh, Edinburg, UK</dd>
+   <span title="German Research Center for Artificial Intelligence (DFKI) Gmbh, GER">Paul Libbrecht</span>,
 
-   <dt>Bruce Miller</dt>
-   <dd>National Institute of Standards and Technology (NIST), Gaithersburg MD, USA</dd>
+   <span title="University of Edinburgh, Edinburg, UK">Manolis Mavrikis</span>,
 
-   <dt>Robert Miner</dt>
-   <dd>Design Science Inc., Long Beach CA, USA</dd>
+   <span title="National Institute of Standards and Technology (NIST), Gaithersburg MD, USA">Bruce Miller</span>,
 
-   <dt>Chris Rowley</dt>
-   <dd>The Open University, UK</dd>
+   <span title="Design Science Inc., Long Beach CA, USA">Robert Miner</span>,
 
-   <dt>Murray Sargent III</dt>
-   <dd>Microsoft, Redmond WA, USA</dd>
+   <span title="The Open University, UK">Chris Rowley</span>,
 
-   <dt>Kyle Siegrist</dt>
-   <dd>Mathematical Association of America, Washington DC, USA</dd>
+   <span title="Microsoft, Redmond WA, USA">Murray Sargent III</span>,
 
-   <dt>Andrew Smith</dt>
-   <dd>Maplesoft Inc., Canada</dd>
+   <span title="Mathematical Association of America, Washington DC, USA">Kyle Siegrist</span>,
 
-   <dt>Neil Soiffer</dt>
-   <dd>Design Science Inc., Long Beach CA, USA</dd>
+   <span title="Maplesoft Inc., Canada">Andrew Smith</span>,
 
-   <dt>Stephen Watt</dt>
-   <dd>University of Western Ontario, London ON, CAN</dd>
+   <span title="Design Science Inc., Long Beach CA, USA">Neil Soiffer</span>,
 
-   <dt>Mohamed Zergaoui</dt>
-   <dd>Innovimax, Paris, FRA</dd>
+   <span title="University of Western Ontario, London ON, CAN">Stephen Watt</span>,
 
-  </dl>
+   <span title="Innovimax, Paris, FRA">Mohamed Zergaoui</span>
+
+  </blockquote>
 
   <p>
    All the above persons have been members of the currently chartered Math Working Group,
@@ -134,162 +106,114 @@
   <p>Participants in the Working Group responsible for MathML 2.0, second
   edition were:
   </p>
-  <dl>
+  <blockquote>
 
-   <dt>Ron Ausbrooks</dt>
-   <dd>Mackichan Software, Las Cruces NM, USA</dd>
+   <span title="Mackichan Software, Las Cruces NM, USA">Ron Ausbrooks</span>,
 
-   <dt>Laurent Bernardin</dt>
-   <dd>Waterloo Maple, Inc., Waterloo ON, CAN</dd>
+   <span title="Waterloo Maple, Inc., Waterloo ON, CAN">Laurent Bernardin</span>,
 
-   <dt>Stephen Buswell</dt>
-   <dd>Stilo Technology Ltd., Bristol, UK</dd>
+   <span title="Stilo Technology Ltd., Bristol, UK">Stephen Buswell</span>,
 
-   <dt>David Carlisle</dt>
-   <dd>NAG Ltd., Oxford, UK</dd>
+   <span title="NAG Ltd., Oxford, UK">David Carlisle</span>,
 
-   <dt>St&#xe9;phane Dalmas</dt>
-   <dd>INRIA, Sophia Antipolis, FR</dd>
+   <span title="INRIA, Sophia Antipolis, FR">St&#xe9;phane Dalmas</span>,
 
-   <dt>Stan Devitt</dt>
-   <dd>Stratum Technical Services Ltd., Waterloo ON, CAN (earlier with Waterloo Maple, Inc.,
-   Waterloo ON, CAN)</dd>
+   <span title="Stratum Technical Services Ltd., Waterloo ON, CAN (earlier with Waterloo Maple, Inc., Waterloo ON, CAN)">Stan Devitt</span>,
 
-   <dt>Max Froumentin</dt>
-   <dd>W3C, Sophia-Antipolis, FRA</dd>
+   <span title="W3C, Sophia-Antipolis, FRA">Max Froumentin</span>,
 
-   <dt>Patrick Ion</dt>
-   <dd>Mathematical Reviews (American Mathematical
-   Society), Ann Arbor MI, USA</dd>
+   <span title="Mathematical Reviews (American Mathematical Society), Ann Arbor MI, USA">Patrick Ion</span>,
 
-   <dt>Michael Kohlhase</dt>
-   <dd>DFKI, GER</dd>
+   <span title="DFKI, GER">Michael Kohlhase</span>,
 
-   <dt>Robert Miner</dt>
-   <dd>Design Science Inc., Long Beach CA, USA</dd>
+   <span title="Design Science Inc., Long Beach CA, USA">Robert Miner</span>,
 
-   <dt>Luca Padovani</dt>
-   <dd>University of Bologna, IT</dd>
+   <span title="University of Bologna, IT">Luca Padovani</span>,
 
-   <dt>Ivor Philips</dt>
-   <dd>Boeing, Seattle WA, USA</dd>
+   <span title="Boeing, Seattle WA, USA">Ivor Philips</span>,
 
-   <dt>Murray Sargent III</dt>
-   <dd>Microsoft, Redmond WA, USA</dd>
+   <span title="Microsoft, Redmond WA, USA">Murray Sargent III</span>,
 
-   <dt>Neil Soiffer</dt>
-   <dd>Wolfram Research Inc., Champaign IL, USA</dd>
+   <span title="Wolfram Research Inc., Champaign IL, USA">Neil Soiffer</span>,
 
-   <dt>Paul Topping</dt>
-   <dd>Design Science Inc., Long Beach CA, USA</dd>
+   <span title="Design Science Inc., Long Beach CA, USA">Paul Topping</span>,
 
-   <dt>Stephen Watt</dt>
-   <dd>University of Western Ontario, London ON, CAN</dd>
-  </dl>
+   <span title="University of Western Ontario, London ON, CAN">Stephen Watt</span>
+  </blockquote>
 
   <p>Earlier active participants of the W3C Math Working Group (2001 &#x2013; 2003) have
   included:
   </p>
-  <dl>
+  <blockquote>
 
-   <dt>Angel Diaz</dt>
-   <dd>IBM Research Division, Yorktown Heights NY, USA</dd>
+   <span title="IBM Research Division, Yorktown Heights NY, USA">Angel Diaz</span>,
 
-   <dt>Sam Dooley</dt>
-   <dd>IBM Research, Yorktown Heights NY, USA</dd>
+   <span title="IBM Research, Yorktown Heights NY, USA">Sam Dooley</span>,
 
-   <dt>Barry MacKichan</dt>
-   <dd>MacKichan Software, Las Cruces NM, USA</dd>
-  </dl>
+   <span title="MacKichan Software, Las Cruces NM, USA">Barry MacKichan</span>
+  </blockquote>
 
   <p>The W3C Math Working Group was co-chaired by Patrick Ion
   of the AMS, and Angel Diaz of IBM from July 1998 to December 2000.</p>
 
   <p>Participants in the Working Group responsible for MathML 2.0 were:
   </p>
-  <dl>
+  <blockquote>
 
-   <dt>Ron Ausbrooks</dt>
-   <dd>Mackichan Software, Las Cruces NM, USA</dd>
+   <span title="Mackichan Software, Las Cruces NM, USA">Ron Ausbrooks</span>,
 
-   <dt>Laurent Bernardin</dt>
-   <dd>Maplesoft, Waterloo ON, CAN</dd>
+   <span title="Maplesoft, Waterloo ON, CAN">Laurent Bernardin</span>,
 
-   <dt>Stephen Buswell</dt>
-   <dd>Stilo Technology Ltd., Cardiff, UK</dd>
+   <span title="Stilo Technology Ltd., Cardiff, UK">Stephen Buswell</span>,
 
-   <dt>David Carlisle</dt>
-   <dd>NAG Ltd., Oxford, UK</dd>
+   <span title="NAG Ltd., Oxford, UK">David Carlisle</span>,
 
-   <dt>St&#xe9;phane Dalmas</dt>
-   <dd>INRIA, Sophia Antipolis, FR</dd>
+   <span title="INRIA, Sophia Antipolis, FR">St&#xe9;phane Dalmas</span>,
 
-   <dt>Stan Devitt</dt>
-   <dd>Stratum Technical Services Ltd., Waterloo ON, CAN (earlier with Waterloo Maple, Inc.,
-   Waterloo ON, CAN)</dd>
+   <span title="Stratum Technical Services Ltd., Waterloo ON, CAN (earlier with Waterloo Maple, Inc., Waterloo ON, CAN)">Stan Devitt</span>,
 
-   <dt>Angel Diaz</dt>
-   <dd>IBM Research Division, Yorktown Heights NY, USA</dd>
+   <span title="IBM Research Division, Yorktown Heights NY, USA">Angel Diaz</span>,
 
-   <dt>Ben Hinkle</dt>
-   <dd>Waterloo Maple, Inc., Waterloo ON, CAN</dd>
+   <span title="Waterloo Maple, Inc., Waterloo ON, CAN">Ben Hinkle</span>,
 
-   <dt>Stephen Hunt</dt>
-   <dd>MATH.EDU Inc., Champaign IL, USA</dd>
+   <span title="MATH.EDU Inc., Champaign IL, USA">Stephen Hunt</span>,
 
-   <dt>Douglas Lovell</dt>
-   <dd>IBM Hawthorne Research, Yorktown Heights NY, USA</dd>
+   <span title="IBM Hawthorne Research, Yorktown Heights NY, USA">Douglas Lovell</span>,
 
-   <dt>Patrick Ion</dt>
-   <dd>Mathematical Reviews (American Mathematical
-   Society), Ann Arbor MI, USA</dd>
+   <span title="Mathematical Reviews (American Mathematical Society), Ann Arbor MI, USA">Patrick Ion</span>,
 
-   <dt>Robert Miner</dt>
-   <dd>Design Science Inc., Long Beach CA, USA (earlier with Geometry Technologies Inc.,
-   Minneapolis MN, USA)</dd>
+   <span title="Design Science Inc., Long Beach CA, USA (earlier with Geometry Technologies Inc., Minneapolis MN, USA)">Robert Miner</span>,
 
-   <dt>Ivor Philips</dt>
-   <dd>Boeing, Seattle WA, USA</dd>
+   <span title="Boeing, Seattle WA, USA">Ivor Philips</span>,
 
-   <dt>Nico Poppelier</dt>
-   <dd>Penta Scope, Amersfoort, NL (earlier with Salience and Elsevier Science, NL)</dd>
+   <span title="Penta Scope, Amersfoort, NL (earlier with Salience and Elsevier Science, NL)">Nico Poppelier</span>,
 
-   <dt>Dave Raggett</dt>
-   <dd>W3C (Openwave), Bristol, UK (earlier with Hewlett-Packard)</dd>
+   <span title="W3C (Openwave), Bristol, UK (earlier with Hewlett-Packard)">Dave Raggett</span>,
 
-   <dt>T.V. Raman</dt>
-   <dd>IBM Almaden, Palo Alto CA, USA (earlier with Adobe Inc., Mountain View CA, USA)</dd>
+   <span title="IBM Almaden, Palo Alto CA, USA (earlier with Adobe Inc., Mountain View CA, USA)">T.V. Raman</span>,
 
-   <dt>Murray Sargent III</dt>
-   <dd>Microsoft, Redmond WA, USA</dd>
+   <span title="Microsoft, Redmond WA, USA">Murray Sargent III</span>,
 
-   <dt>Neil Soiffer</dt>
-   <dd>Wolfram Research Inc., Champaign IL, USA</dd>
+   <span title="Wolfram Research Inc., Champaign IL, USA">Neil Soiffer</span>,
 
-   <dt>Irene Schena</dt>
-   <dd>Universit&#xe1; di Bologna, Bologna, IT</dd>
+   <span title="Universit&#xe1; di Bologna, Bologna, IT">Irene Schena</span>,
 
-   <dt>Paul Topping</dt>
-   <dd>Design Science Inc., Long Beach CA, USA</dd>
+   <span title="Design Science Inc., Long Beach CA, USA">Paul Topping</span>,
 
-   <dt>Stephen Watt</dt>
-   <dd>University of Western Ontario, London ON, CAN</dd>
-  </dl>
+   <span title="University of Western Ontario, London ON, CAN">Stephen Watt</span>
+  </blockquote>
 
   <p>Earlier active participants of this second W3C Math Working Group have
   included:
   </p>
-  <dl>
+  <blockquote>
 
-   <dt>Sam Dooley</dt>
-   <dd>IBM Research, Yorktown Heights NY, USA</dd>
+   <span title="IBM Research, Yorktown Heights NY, USA">Sam Dooley</span>,
 
-   <dt>Robert Sutor</dt>
-   <dd>IBM Research, Yorktown Heights NY, USA</dd>
+   <span title="IBM Research, Yorktown Heights NY, USA">Robert Sutor</span>,
 
-   <dt>Barry MacKichan</dt>
-   <dd>MacKichan Software, Las Cruces NM, USA</dd>
-  </dl>
+   <span title="MacKichan Software, Las Cruces NM, USA">Barry MacKichan</span>
+  </blockquote>
 
   <p>At the time of release of MathML 1.0 [[MathML1]] the
   Math Working Group was co-chaired by Patrick Ion and Robert Miner, then of the
@@ -301,85 +225,61 @@
   <p>Participants in the Math Working Group responsible for the finished
   MathML 1.0 specification were:
   </p>
-  <dl>
+  <blockquote>
 
-   <dt>Stephen Buswell</dt>
-   <dd>Stilo Technology Ltd., Cardiff, UK</dd>
+   <span title="Stilo Technology Ltd., Cardiff, UK">Stephen Buswell</span>,
 
-   <dt>St&#xe9;phane Dalmas</dt>
-   <dd>INRIA, Sophia Antipolis, FR</dd>
+   <span title="INRIA, Sophia Antipolis, FR">St&#xe9;phane Dalmas</span>,
 
-   <dt>Stan Devitt</dt>
-   <dd>Maplesoft Inc., Waterloo ON, CAN</dd>
+   <span title="Maplesoft Inc., Waterloo ON, CAN">Stan Devitt</span>,
 
-   <dt>Angel Diaz</dt>
-   <dd>IBM Research Division, Yorktown Heights NY, USA</dd>
+   <span title="IBM Research Division, Yorktown Heights NY, USA">Angel Diaz</span>,
 
-   <dt>Brenda Hunt</dt>
-   <dd>Wolfram Research Inc., Champaign IL, USA</dd>
+   <span title="Wolfram Research Inc., Champaign IL, USA">Brenda Hunt</span>,
 
-   <dt>Stephen Hunt</dt>
-   <dd>Wolfram Research Inc., Champaign IL, USA</dd>
+   <span title="Wolfram Research Inc., Champaign IL, USA">Stephen Hunt</span>,
 
-   <dt>Patrick Ion</dt>
-   <dd>Mathematical Reviews (American Mathematical
-   Society), Ann Arbor MI, USA</dd>
+   <span title="Mathematical Reviews (American Mathematical Society), Ann Arbor MI, USA">Patrick Ion</span>,
 
-   <dt>Robert Miner</dt>
-   <dd>Geometry Center, University of Minnesota, Minneapolis
-   MN, USA</dd>
+   <span title="Geometry Center, University of Minnesota, Minneapolis MN, USA">Robert Miner</span>,
 
-   <dt>Nico Poppelier</dt>
-   <dd>Elsevier Science, Amsterdam, NL</dd>
+   <span title="Elsevier Science, Amsterdam, NL">Nico Poppelier</span>,
 
-   <dt>Dave Raggett</dt>
-   <dd>W3C (Hewlett Packard), Bristol, UK</dd>
+   <span title="W3C (Hewlett Packard), Bristol, UK">Dave Raggett</span>,
 
-   <dt>T.V. Raman</dt>
-   <dd>Adobe Inc., Mountain View CA, USA</dd>
+   <span title="Adobe Inc., Mountain View CA, USA">T.V. Raman</span>,
 
-   <dt>Bruce Smith</dt>
-   <dd>Wolfram Research Inc., Champaign IL, USA</dd>
+   <span title="Wolfram Research Inc., Champaign IL, USA">Bruce Smith</span>,
 
-   <dt>Neil Soiffer</dt>
-   <dd>Wolfram Research Inc., Champaign IL, USA</dd>
+   <span title="Wolfram Research Inc., Champaign IL, USA">Neil Soiffer</span>,
 
-   <dt>Robert Sutor</dt>
-   <dd>IBM Research, Yorktown Heights NY, USA</dd>
+   <span title="IBM Research, Yorktown Heights NY, USA">Robert Sutor</span>,
 
-   <dt>Paul Topping</dt>
-   <dd>Design Science Inc., Long Beach CA, USA</dd>
+   <span title="Design Science Inc., Long Beach CA, USA">Paul Topping</span>,
 
-   <dt>Stephen Watt</dt>
-   <dd>University of Western Ontario, London ON, CAN</dd>
+   <span title="University of Western Ontario, London ON, CAN">Stephen Watt</span>,
 
-   <dt>Ralph Youngen</dt>
-   <dd>American Mathematical Society, Providence RI, USA</dd>
+   <span title="American Mathematical Society, Providence RI, USA">Ralph Youngen</span>
 
-  </dl>
+  </blockquote>
   <p>
 
    Others who had been members of the W3C Math WG for periods at
    earlier stages were:
 
   </p>
-  <dl>
+  <blockquote>
 
-   <dt>Stephen Glim</dt>
-   <dd>Mathsoft Inc., Cambridge MA, USA</dd>
+   <span title="Mathsoft Inc., Cambridge MA, USA">Stephen Glim</span>,
 
-   <dt>Arnaud Le Hors</dt>
-   <dd>W3C, Cambridge MA, USA</dd>
+   <span title="W3C, Cambridge MA, USA">Arnaud Le Hors</span>,
 
-   <dt>Ron Whitney</dt>
-   <dd>Texterity Inc., Boston MA, USA</dd>
+   <span title="Texterity Inc., Boston MA, USA">Ron Whitney</span>,
 
-   <dt>Lauren Wood</dt>
-   <dd>SoftQuad, Surrey BC, CAN</dd>
+   <span title="SoftQuad, Surrey BC, CAN">Lauren Wood</span>,
 
-   <dt>Ka-Ping Yee</dt>
-   <dd>University of Waterloo, Waterloo ON, CAN</dd>
-  </dl>
+   <span title="University of Waterloo, Waterloo ON, CAN">Ka-Ping Yee</span>
+  </blockquote>
  </section>
 
  <section>

--- a/src/respec.rnc
+++ b/src/respec.rnc
@@ -2,7 +2,7 @@ start = html|section
 
 html = element html {head,body}
 
-head = element head {meta+,title,link*,style*,script*}
+head = element head {meta+,title,link*,script*,style*}
 
 meta = element meta {
  attribute charset {"UTF-8"} |
@@ -266,7 +266,7 @@ attribute data-diff {text}?,
 attribute title {text}?,
 inlinecontent}
 
-span = element dfn {
+dfn = element dfn {
 attribute id {text}?,
 inlinecontent}
 


### PR DESCRIPTION
The contributors lists in appendix E take up a lot of space (even before we add any new list for MathML4).  This is a fairly mild re-arrangement keeping all the list text but displaying the list of names inline rather than a description list, with affiliations just in `title` attribute popups.

so taking just one of the lists 

![image](https://user-images.githubusercontent.com/1268738/157282574-d1fc84ca-65ba-4834-be23-56e0d8c0672a.png)


becomes

![image](https://user-images.githubusercontent.com/1268738/157282803-b7e6b37c-f8cb-428a-9363-a8098bad514c.png)

We could compress further eg merge the lists for mathml 1/2/3 since most people appear at least twice, but starting with small steps.

I suspect most specs don't now list full WG membership just a subset of "authors" or smaller subset of "editors" but previously we have conciously listed everyone not least because some contributors for whom English isn't their first language have contributed in ways other than actually editing the text, and would not be recognised 

I pinged the co-chairs for review as this is a policy thing rather than anything else, but anyone feel free to comment.


