### PR TITLE
delete statement that content mathml can be used in csymbol fixes #276

### DIFF
--- a/src/mixing.html
+++ b/src/mixing.html
@@ -917,12 +917,8 @@
 
     <dt>Presentation markup within the <code class="element">csymbol</code> element.</dt>
     <dd>
-     <p>The <code class="element">csymbol</code> element may contain either MathML characters
-     interspersed with presentation markup, or content markup.  It is a MathML
-     error for a <code class="element">csymbol</code> element to contain both presentation and
-     content elements.  When the <code class="element">csymbol</code> element contains
-     character data and presentation markup, the same rendering rules that apply
-       to the token elements <code class="element">ci</code> and <code class="element">cn</code> should be used.</p>
+     <p>The same rendering rules that apply
+       to the token elements <code class="element">ci</code> and <code class="element">cn</code> should be used for the <code class="element">csymbol</code> element.</p>
       <div class="issue" data-number="276"></div>
     </dd>
 


### PR DESCRIPTION
Chapter 5 will need further changes, but this just deletes this one bad paragraph, to make close the issue here, ad to ensure it doesn't get left in by mistake.