### PR TITLE
add core yes/no by css not by explicit content

### DIFF
--- a/index.html
+++ b/index.html
@@ -153,7 +153,11 @@
   <style>
 th.mfont, span.mfont{
 	font-family:"STIX Two Math", "Cambria Math", "STIX Math", "Asana Math", "serif";
-    }
+}
+a.coreyes::before{content:"core\2714;";color:green;}
+li span.formerLink::before{content:"core\2714;";color:green;}
+div.header-wrapper span.coreno::before{content:"core\2716;";color:red;}
+li.tocline span.coreno::before{content:"core\2716;";color:red;}
 summary.H4 {
 font-weight:bold;
 color:var(--heading-text);

--- a/src/presentation-markup.html
+++ b/src/presentation-markup.html
@@ -2000,7 +2000,6 @@
  <section>
   <h4 id="presm_mi" data-coreref="dfn-mi">Identifier <code class="defn starttag">&lt;mi&gt;</code></h4>
 
-  <p>xxxx <a href="#presm_mi"></a> xxxx <a href="#presm_mo"></a></p>
  <section>
    <h5>Description</h5>
 

--- a/src/presentation-markup.html
+++ b/src/presentation-markup.html
@@ -1250,7 +1250,7 @@
      <td rowspan="2" class="attname">mathcolor</td>
      <td><a class="intref" href="#type_color"><em>color</em></a></td>
      <td><em>inherited</em></td>
-     <td><a class="coreyes" href="https://w3c.github.io/mathml-core/#mathmltree.p4">core&#x2714;</a></td>
+     <td><a class="coreyes" href="https://w3c.github.io/mathml-core/#mathmltree.p4"></a></td>
     </tr>
 
     <tr>
@@ -1266,7 +1266,7 @@
      <td rowspan="2" class="attname">mathbackground</td>
      <td><a class="intref" href="#type_color"><em>color</em></a> | "transparent"</td>
      <td>transparent</td>
-     <td><span class="coreno">core&#x2716;</span></td>
+     <td><span class="coreno"></span></td>
     </tr>
 
     <tr>
@@ -1351,7 +1351,7 @@
 
  <section>
   <h4 id="presm_tokenchars">
-  <span>Token Element Content Characters, <code class="emptytag">&lt;mglyph/&gt;</code></span> <span class="coreno">core&#x2716;</span></h4>
+  <span>Token Element Content Characters, <code class="emptytag">&lt;mglyph/&gt;</code></span> <span class="coreno"></span></h4>
 
   <p>Character data in MathML markup is only allowed to occur as part of
   the content of token elements.  Whitespace between elements is ignored.
@@ -1484,7 +1484,7 @@
        <td rowspan="2" class="attname">src</td>
        <td><a class="intref" href="#type_uri"><em>URI</em></a></td>
        <td><em>required</em></td>
-       <td><span class="coreno">core&#x2716;</span></td>
+       <td><span class="coreno"></span></td>
       </tr>
 
       <tr>
@@ -1498,7 +1498,7 @@
        <td rowspan="2" class="attname">width</td>
        <td><a class="intref" href="#type_length"><em>length</em></a></td>
        <td><em>from image</em></td>
-       <td><span class="coreno">core&#x2716;</span></td>
+       <td><span class="coreno"></span></td>
       </tr>
 
       <tr>
@@ -1511,7 +1511,7 @@
        <td rowspan="2" class="attname">height</td>
        <td><a class="intref" href="#type_length"><em>length</em></a></td>
        <td><em>from image</em></td>
-       <td><span class="coreno">core&#x2716;</span></td>
+       <td><span class="coreno"></span></td>
       </tr>
 
       <tr>
@@ -1527,7 +1527,7 @@
        <td rowspan="2" class="attname">valign</td>
        <td><a class="intref" href="#type_length"><em>length</em></a> </td>
        <td>0ex</td>
-       <td><span class="coreno">core&#x2716;</span></td>
+       <td><span class="coreno"></span></td>
       </tr>
 
       <tr>
@@ -1544,7 +1544,7 @@
        <td rowspan="2" class="attname">alt</td>
        <td><a class="intref" href="#type_string"><em>string</em></a></td>
        <td><em>required</em></td>
-       <td><span class="coreno">core&#x2716;</span></td>
+       <td><span class="coreno"></span></td>
       </tr>
 
       <tr>
@@ -1614,7 +1614,7 @@
       <tr>
        <td rowspan="2" class="attname">fontfamily</td>
        <td><a class="intref" href="#type_string"><em>string</em></a></td>
-       <td><span class="coreno">core&#x2716;</span></td>
+       <td><span class="coreno"></span></td>
       </tr>
 
       <tr>
@@ -1628,7 +1628,7 @@
       <tr>
        <td rowspan="2" class="attname">index</td>
        <td><a class="intref" href="#type_integer"><em>integer</em></a></td>
-       <td><span class="coreno">core&#x2716;</span></td>
+       <td><span class="coreno"></span></td>
       </tr>
 
       <tr>
@@ -1689,7 +1689,7 @@
       "initial" | "tailed" | "looped" | "stretched"
      </td>
      <td>normal (<em>except on</em> <code class="starttag">&lt;mi&gt;</code>)</td>
-     <td><span class="coreno">core&#x2716;</span></td>
+     <td><span class="coreno"></span></td>
     </tr>
 
     <tr>
@@ -1703,7 +1703,7 @@
      <td rowspan="2" class="attname">mathsize</td>
      <td>"small" | "normal" | "big" | <a class="intref" href="#type_length"><em>length</em></a></td>
      <td><em>inherited</em></td>
-     <td><span class="coreno">core&#x2716;</span></td>
+     <td><span class="coreno"></span></td>
     </tr>
 
     <tr>
@@ -1720,7 +1720,7 @@
      <td rowspan="2" class="attname">dir</td>
      <td>"ltr" | "rtl"</td>
      <td><em>inherited</em></td>
-     <td><span class="coreno">core&#x2716;</span></td>
+     <td><span class="coreno"></span></td>
     </tr>
 
     <tr>
@@ -1835,7 +1835,7 @@
   in some of their children; see the discussion in <a href="#presm_scriptlevel"></a>.</p>
 
   <section>
-   <h5 id="presm_deprecatt">Deprecated style attributes on token elements <span class="coreno">core&#x2716;</span></h5>
+   <h5 id="presm_deprecatt">Deprecated style attributes on token elements <span class="coreno"></span></h5>
 
    <p>The MathML 1.01 style attributes listed below
    are <a class="intref" href="#interf_deprec">deprecated</a> in MathML 2 and 3.
@@ -1868,7 +1868,7 @@
       <td rowspan="2" class="attname">fontfamily</td>
       <td><a class="intref" href="#type_string"><em>string</em></a></td>
       <td><em>inherited</em></td>
-      <td><span class="coreno">core&#x2716;</span></td>
+      <td><span class="coreno"></span></td>
      </tr>
 
      <tr>
@@ -1884,7 +1884,7 @@
       <td rowspan="2" class="attname">fontweight</td>
       <td>"normal" | "bold"</td>
       <td><em>inherited</em></td>
-      <td><span class="coreno">core&#x2716;</span></td>
+      <td><span class="coreno"></span></td>
      </tr>
 
      <tr>
@@ -1898,7 +1898,7 @@
       <td rowspan="2" class="attname">fontstyle</td>
       <td>"normal" | "italic"</td>
       <td>normal (<em>except on</em> <code class="starttag">&lt;mi&gt;</code>)</td>
-      <td><span class="coreno">core&#x2716;</span></td>
+      <td><span class="coreno"></span></td>
      </tr>
 
      <tr>
@@ -1912,7 +1912,7 @@
       <td rowspan="2" class="attname">fontsize</td>
       <td><a class="intref" href="#type_length"><em>length</em></a></td>
       <td><em>inherited</em></td>
-      <td><span class="coreno">core&#x2716;</span></td>
+      <td><span class="coreno"></span></td>
      </tr>
 
      <tr>
@@ -1926,7 +1926,7 @@
       <td rowspan="2" class="attname">color</td>
       <td><a class="intref" href="#type_color"><em>color</em></a></td>
       <td><em>inherited</em></td>
-      <td><span class="coreno">core&#x2716;</span></td>
+      <td><span class="coreno"></span></td>
      </tr>
 
      <tr>
@@ -1940,7 +1940,7 @@
       <td rowspan="2" class="attname">background</td>
       <td><a class="intref" href="#type_color"><em>color</em></a> | "transparent"</td>
       <td>transparent</td>
-      <td><span class="coreno">core&#x2716;</span></td>
+      <td><span class="coreno"></span></td>
      </tr>
 
      <tr>
@@ -1995,12 +1995,13 @@
     </pre>
    </div>
   </section>
- </section>
+  </section>
 
  <section>
-  <h4 id="presm_mi">Identifier <code class="defn starttag">&lt;mi&gt;</code> <a class="coreyes" href="https://w3c.github.io/mathml-core/#dfn-mi">core&#x2714;</a></h4>
+  <h4 id="presm_mi" data-coreref="dfn-mi">Identifier <code class="defn starttag">&lt;mi&gt;</code></h4>
 
-  <section>
+  <p>xxxx <a href="#presm_mi"></a> xxxx <a href="#presm_mo"></a></p>
+ <section>
    <h5>Description</h5>
 
    <p>An <code class="element">mi</code> element represents a symbolic name or
@@ -2061,7 +2062,7 @@
       "initial" | "tailed" | "looped" | "stretched"
       </td>
       <td><em>(depends on content; described below)</em></td>
-      <td><span class="coreno">core&#x2716;</span></td>
+      <td><span class="coreno"></span></td>
      </tr>
 
      <tr>
@@ -2171,7 +2172,7 @@
  </section>
 
  <section>
-  <h4 id="presm_mn">Number <code class="defn starttag">&lt;mn&gt;</code> <a class="coreyes" href="https://w3c.github.io/mathml-core/#dfn-mn">core&#x2714;</a></h4>
+  <h4 id="presm_mn">Number <code class="defn starttag">&lt;mn&gt;</code> <a class="coreyes" href="https://w3c.github.io/mathml-core/#dfn-mn"></a></h4>
 
   <section>
    <h5>Description</h5>
@@ -2291,7 +2292,7 @@
 
  <section>
   <h4 id="presm_mo">Operator, Fence, Separator or Accent
-  <code class="defn starttag">&lt;mo&gt;</code> <a class="coreyes" href="https://w3c.github.io/mathml-core/#dfn-mo">core&#x2714;</a></h4>
+  <code class="defn starttag">&lt;mo&gt;</code> <a class="coreyes" href="https://w3c.github.io/mathml-core/#dfn-mo"></a></h4>
 
   <section>
    <h5>Description</h5>
@@ -2407,7 +2408,7 @@
        <td rowspan="2" class="attname">form</td>
        <td>"prefix" | "infix" | "postfix"</td>
        <td><em>set by position of operator in an</em> <code class="element">mrow</code></td>
-       <td><span class="coreno">core&#x2716;</span></td>
+       <td><span class="coreno"></span></td>
       </tr>
 
       <tr>
@@ -2424,7 +2425,7 @@
        <td rowspan="2" class="attname">fence</td>
        <td>"true" | "false"</td>
        <td><em>set by dictionary</em> (false)</td>
-       <td><span class="coreno">core&#x2716;</span></td>
+       <td><span class="coreno"></span></td>
       </tr>
 
       <tr>
@@ -2439,7 +2440,7 @@
        <td rowspan="2" class="attname">separator</td>
        <td>"true" | "false"</td>
        <td><em>set by dictionary</em> (false)</td>
-       <td><span class="coreno">core&#x2716;</span></td>
+       <td><span class="coreno"></span></td>
       </tr>
 
       <tr>
@@ -2454,7 +2455,7 @@
        <td rowspan="2" class="attname">lspace</td>
        <td><a class="intref" href="#type_length"><em>length</em></a></td>
        <td><em>set by dictionary</em> (thickmathspace)</td>
-       <td><span class="coreno">core&#x2716;</span></td>
+       <td><span class="coreno"></span></td>
       </tr>
 
       <tr>
@@ -2469,7 +2470,7 @@
        <td rowspan="2" class="attname">rspace</td>
        <td><a class="intref" href="#type_length"><em>length</em></a></td>
        <td><em>set by dictionary</em> (thickmathspace)</td>
-       <td><span class="coreno">core&#x2716;</span></td>
+       <td><span class="coreno"></span></td>
       </tr>
 
       <tr>
@@ -2484,7 +2485,7 @@
        <td rowspan="2" class="attname">stretchy</td>
        <td>"true" | "false"</td>
        <td><em>set by dictionary</em> (false)</td>
-       <td><span class="coreno">core&#x2716;</span></td>
+       <td><span class="coreno"></span></td>
       </tr>
 
       <tr>
@@ -2498,7 +2499,7 @@
        <td rowspan="2" class="attname">symmetric</td>
        <td>"true" | "false"</td>
        <td><em>set by dictionary</em> (false)</td>
-       <td><span class="coreno">core&#x2716;</span></td>
+       <td><span class="coreno"></span></td>
       </tr>
 
       <tr>
@@ -2514,7 +2515,7 @@
        <td rowspan="2" class="attname">maxsize</td>
        <td> <a class="intref" href="#type_length"><em>length</em></a> | "infinity"</td>
        <td><em>set by dictionary</em> (infinity)</td>
-       <td><span class="coreno">core&#x2716;</span></td>
+       <td><span class="coreno"></span></td>
       </tr>
 
       <tr>
@@ -2530,7 +2531,7 @@
        <td rowspan="2" class="attname">minsize</td>
        <td> <a class="intref" href="#type_length"><em>length</em></a></td>
        <td><em>set by dictionary</em> <span>(100%)</span></td>
-       <td><span class="coreno">core&#x2716;</span></td>
+       <td><span class="coreno"></span></td>
       </tr>
 
       <tr>
@@ -2546,7 +2547,7 @@
        <td rowspan="2" class="attname">largeop</td>
        <td>"true" | "false"</td>
        <td><em>set by dictionary</em> (false)</td>
-       <td><span class="coreno">core&#x2716;</span></td>
+       <td><span class="coreno"></span></td>
       </tr>
 
       <tr>
@@ -2565,7 +2566,7 @@
        <td rowspan="2" class="attname">movablelimits</td>
        <td>"true" | "false"</td>
        <td><em>set by dictionary</em> (false)</td>
-       <td><span class="coreno">core&#x2716;</span></td>
+       <td><span class="coreno"></span></td>
       </tr>
 
       <tr>
@@ -2583,7 +2584,7 @@
        <td rowspan="2" class="attname">accent</td>
        <td>"true" | "false"</td>
        <td><em>set by dictionary</em> (false)</td>
-       <td><span class="coreno">core&#x2716;</span></td>
+       <td><span class="coreno"></span></td>
       </tr>
 
       <tr>
@@ -2624,7 +2625,7 @@
        <td rowspan="2" class="attname">linebreak</td>
        <td>"auto" | "newline" | "nobreak" | "goodbreak" | "badbreak"</td>
        <td>auto</td>
-       <td><span class="coreno">core&#x2716;</span></td>
+       <td><span class="coreno"></span></td>
       </tr>
 
       <tr>
@@ -2643,7 +2644,7 @@
        <td rowspan="2" class="attname">lineleading </td>
        <td> <a class="intref" href="#type_length"><em>length</em></a> </td>
        <td><em>inherited</em> (100%) </td>
-       <td><span class="coreno">core&#x2716;</span></td>
+       <td><span class="coreno"></span></td>
       </tr>
 
       <tr>
@@ -2659,7 +2660,7 @@
        <td> "before" | "after" | "duplicate"
        | "infixlinebreakstyle"</td>
        <td><em>set by dictionary</em> (before) </td>
-       <td><span class="coreno">core&#x2716;</span></td>
+       <td><span class="coreno"></span></td>
       </tr>
 
       <tr>
@@ -2682,7 +2683,7 @@
        <td rowspan="2" class="attname">linebreakmultchar</td>
        <td><a class="intref" href="#type_string"><em>string</em></a></td>
        <td><em>inherited</em> (&amp;InvisibleTimes;) </td>
-       <td><span class="coreno">core&#x2716;</span></td>
+       <td><span class="coreno"></span></td>
       </tr>
 
       <tr>
@@ -2747,7 +2748,7 @@
        <td rowspan="2" class="attname">indentalign</td>
        <td>"left" | "center" | "right" | "auto" | "id"</td>
        <td><em>inherited</em> (auto)       </td>
-       <td><span class="coreno">core&#x2716;</span></td>
+       <td><span class="coreno"></span></td>
       </tr>
 
       <tr>
@@ -2761,7 +2762,7 @@
        <td rowspan="2" class="attname">indentshift      </td>
        <td><a class="intref" href="#type_length"><em>length</em></a></td>
        <td><em>inherited</em> (0) </td>
-       <td><span class="coreno">core&#x2716;</span></td>
+       <td><span class="coreno"></span></td>
       </tr>
 
       <tr>
@@ -2780,7 +2781,7 @@
        <td rowspan="2" class="attname">indenttarget</td>
        <td><a class="intref" href="#type_idref"><em>idref</em></a></td>
        <td><em> inherited (none)</em></td>
-       <td><span class="coreno">core&#x2716;</span></td>
+       <td><span class="coreno"></span></td>
       </tr>
 
       <tr>
@@ -2802,7 +2803,7 @@
        <td rowspan="2" class="attname">indentalignfirst  </td>
        <td>"left" | "center" | "right" | "auto" | "id" | "indentalign"</td>
        <td><em>inherited</em> (indentalign) </td>
-       <td><span class="coreno">core&#x2716;</span></td>
+       <td><span class="coreno"></span></td>
       </tr>
 
       <tr>
@@ -2817,7 +2818,7 @@
        <td rowspan="2" class="attname">indentshiftfirst </td>
        <td><a class="intref" href="#type_length"><em>length</em></a> | "indentshift"  </td>
        <td><em>inherited</em> (indentshift) </td>
-       <td><span class="coreno">core&#x2716;</span></td>
+       <td><span class="coreno"></span></td>
       </tr>
 
       <tr>
@@ -2833,7 +2834,7 @@
        <td rowspan="2" class="attname">indentalignlast   </td>
        <td>"left" | "center" | "right" | "auto" | "id" | "indentalign"</td>
        <td><em>inherited</em> (indentalign) </td>
-       <td><span class="coreno">core&#x2716;</span></td>
+       <td><span class="coreno"></span></td>
       </tr>
 
       <tr>
@@ -2851,7 +2852,7 @@
        <td rowspan="2" class="attname">indentshiftlast  </td>
        <td><a class="intref" href="#type_length"><em>length</em></a> | "indentshift" </td>
        <td><em>inherited</em> (indentshift) </td>
-       <td><span class="coreno">core&#x2716;</span></td>
+       <td><span class="coreno"></span></td>
       </tr>
 
       <tr>
@@ -3776,7 +3777,7 @@ is not needed because that is the default value.  </p>
 </section>
 
 <section>
- <h4 id="presm_mtext">Text <code class="defn starttag">&lt;mtext&gt;</code> <a class="coreyes" href="https://w3c.github.io/mathml-core/#dfn-mtext">core&#x2714;</a></h4>
+ <h4 id="presm_mtext">Text <code class="defn starttag">&lt;mtext&gt;</code> <a class="coreyes" href="https://w3c.github.io/mathml-core/#dfn-mtext"></a></h4>
 
  <section>
 <h5>Description</h5>
@@ -3902,7 +3903,7 @@ an <code class="element">mtext</code> element.</p>
 </section>
 
 <section>
- <h4 id="presm_mspace">Space <code class="defn emptytag">&lt;mspace/&gt;</code> <a class="coreyes" href="https://w3c.github.io/mathml-core/#dfn-mspace">core&#x2714;</a></h4>
+ <h4 id="presm_mspace">Space <code class="defn emptytag">&lt;mspace/&gt;</code> <a class="coreyes" href="https://w3c.github.io/mathml-core/#dfn-mspace"></a></h4>
 
  <section>
 <h5>Description</h5>
@@ -3952,7 +3953,7 @@ attributes (see <a href="#fund_units"></a>).
 <td rowspan="2" class="attname">width</td>
 <td><a class="intref" href="#type_length"><em>length</em></a></td>
 <td>0em</td>
-<td><span class="coreno">core&#x2716;</span></td>
+<td><span class="coreno"></span></td>
 </tr>
 
 <tr>
@@ -3965,7 +3966,7 @@ attributes (see <a href="#fund_units"></a>).
 <td rowspan="2" class="attname">height</td>
 <td><a class="intref" href="#type_length"><em>length</em></a></td>
 <td>0ex</td>
-<td><span class="coreno">core&#x2716;</span></td>
+<td><span class="coreno"></span></td>
 </tr>
 
 <tr>
@@ -3978,7 +3979,7 @@ attributes (see <a href="#fund_units"></a>).
  <td rowspan="2" class="attname">depth</td>
 <td><a class="intref" href="#type_length"><em>length</em></a></td>
 <td>0ex</td>
-<td><span class="coreno">core&#x2716;</span></td>
+<td><span class="coreno"></span></td>
 </tr>
 
 <tr>
@@ -3991,7 +3992,7 @@ attributes (see <a href="#fund_units"></a>).
 <td rowspan="2" class="attname">linebreak</td>
 <td>"auto" | "newline" | "nobreak" | "goodbreak" | "badbreak"</td>
 <td>auto</td>
-<td><span class="coreno">core&#x2716;</span></td>
+<td><span class="coreno"></span></td>
 </tr>
 
 <tr>
@@ -4144,7 +4145,7 @@ the correct expression would be:
 </section>
 
 <section>
- <h4 id="presm_ms">String Literal <code class="defn starttag">&lt;ms&gt;</code> <a class="coreyes" href="https://w3c.github.io/mathml-core/#dfn-ms">core&#x2714;</a></h4>
+ <h4 id="presm_ms">String Literal <code class="defn starttag">&lt;ms&gt;</code> <a class="coreyes" href="https://w3c.github.io/mathml-core/#dfn-ms"></a></h4>
 
  <section>
   <h5>Description</h5>
@@ -4206,7 +4207,7 @@ the content should be encoded as described in that section.</p>
 <td rowspan="2" class="attname">lquote</td>
 <td><a class="intref" href="#type_string"><em>string</em></a></td>
 <td><code class="entity">quot</code></td>
-<td><span class="coreno">core&#x2716;</span></td>
+<td><span class="coreno"></span></td>
 </tr>
 
 <tr>
@@ -4220,7 +4221,7 @@ the content should be encoded as described in that section.</p>
 <td rowspan="2" class="attname">rquote</td>
 <td><a class="intref" href="#type_string"><em>string</em></a></td>
 <td><code class="entity">quot</code></td>
-<td><span class="coreno">core&#x2716;</span></td>
+<td><span class="coreno"></span></td>
 </tr>
 
 <tr>
@@ -4250,7 +4251,7 @@ the content should be encoded as described in that section.</p>
 
  <section>
   <h4 id="presm_mrow">Horizontally Group Sub-Expressions
-<code class="defn starttag">&lt;mrow&gt;</code> <a class="coreyes" href="https://w3c.github.io/mathml-core/#dfn-mrow">core&#x2714;</a></h4>
+<code class="defn starttag">&lt;mrow&gt;</code> <a class="coreyes" href="https://w3c.github.io/mathml-core/#dfn-mrow"></a></h4>
 
 <section>
 <h5>Description</h5>
@@ -4315,7 +4316,7 @@ on other elements (See <a href="#presm_linebreaking"></a>).
 <td rowspan="2" class="attname">dir</td>
 <td>"ltr" | "rtl"</td>
 <td><em>inherited</em></td>
-<td><span class="coreno">core&#x2716;</span></td>
+<td><span class="coreno"></span></td>
 </tr>
 
 <tr>
@@ -4461,7 +4462,7 @@ separator <span>&#x201c;operators&#x201d;</span>, do not act together on their a
 </section>
 
 <section>
-<h4 id="presm_mfrac">Fractions <code class="defn starttag">&lt;mfrac&gt;</code> <a class="coreyes" href="https://w3c.github.io/mathml-core/#dfn-mfrac">core&#x2714;</a></h4>
+<h4 id="presm_mfrac">Fractions <code class="defn starttag">&lt;mfrac&gt;</code> <a class="coreyes" href="https://w3c.github.io/mathml-core/#dfn-mfrac"></a></h4>
 
 <section>
 <h5>Description</h5>
@@ -4509,7 +4510,7 @@ The fraction line, if any, should be drawn using the color specified by <code cl
 <td rowspan="2" class="attname">linethickness</td>
 <td> <a class="intref" href="#type_length"><em>length</em></a> | "thin" | "medium" | "thick"</td>
 <td>medium</td>
-<td><span class="coreno">core&#x2716;</span></td>
+<td><span class="coreno"></span></td>
 </tr>
 
 <tr>
@@ -4526,7 +4527,7 @@ the exact thickness of these is left up to the rendering agent.
 <td rowspan="2" class="attname">numalign</td>
 <td>"left" | "center" | "right"</td>
 <td>center</td>
-<td><span class="coreno">core&#x2716;</span></td>
+<td><span class="coreno"></span></td>
 </tr>
 
 <tr>
@@ -4539,7 +4540,7 @@ the exact thickness of these is left up to the rendering agent.
 <td rowspan="2" class="attname">denomalign</td>
 <td>"left" | "center" | "right"</td>
 <td>center</td>
-<td><span class="coreno">core&#x2716;</span></td>
+<td><span class="coreno"></span></td>
 </tr>
 
 <tr>
@@ -4552,7 +4553,7 @@ the exact thickness of these is left up to the rendering agent.
 <td rowspan="2" class="attname">bevelled</td>
 <td>"true" | "false"</td>
 <td>false</td>
-<td><span class="coreno">core&#x2716;</span></td>
+<td><span class="coreno"></span></td>
 </tr>
 
 <tr>
@@ -4678,8 +4679,8 @@ These cases are shown below:
 </section>
 
 <section>
- <h4 id="presm_mroot">Radicals <code class="defn starttag">&lt;msqrt&gt;</code> <span class="coreno">core&#x2716;</span>,
-<code class="defn starttag">&lt;mroot&gt;</code> <a class="coreyes" href="https://w3c.github.io/mathml-core/#dfn-msqrt">core&#x2714;</a></h4>
+ <h4 id="presm_mroot">Radicals <code class="defn starttag">&lt;msqrt&gt;</code> <span class="coreno"></span>,
+<code class="defn starttag">&lt;mroot&gt;</code> <a class="coreyes" href="https://w3c.github.io/mathml-core/#dfn-msqrt"></a></h4>
 
 <section>
 <h5>Description</h5>
@@ -4724,7 +4725,7 @@ color specified by <code class="attribute">mathcolor</code>.</p>
 </section>
 
 <section>
- <h4 id="presm_mstyle">Style Change <code class="defn starttag">&lt;mstyle&gt;</code> <a class="coreyes" href="https://w3c.github.io/mathml-core/#dfn-mstyle">core&#x2714;</a></h4>
+ <h4 id="presm_mstyle">Style Change <code class="defn starttag">&lt;mstyle&gt;</code> <a class="coreyes" href="https://w3c.github.io/mathml-core/#dfn-mstyle"></a></h4>
 
  <section>
 <h5>Description</h5>
@@ -4882,7 +4883,7 @@ part of its rendering environment:
 <td rowspan="2" class="attname">scriptlevel</td>
 <td>( "+" | "-" )? <a class="intref" href="#type_unsigned-integer"><em>unsigned-integer</em></a></td>
 <td><em>inherited</em></td>
-<td><span class="coreno">core&#x2716;</span></td>
+<td><span class="coreno"></span></td>
 </tr>
 
 <tr>
@@ -4900,7 +4901,7 @@ part of its rendering environment:
  <td rowspan="2" class="attname">displaystyle</td>
 <td>"true" | "false"</td>
 <td><em>inherited</em></td>
-<td><span class="coreno">core&#x2716;</span></td>
+<td><span class="coreno"></span></td>
 </tr>
 
 <tr>
@@ -4914,7 +4915,7 @@ part of its rendering environment:
 <td rowspan="2" class="attname">scriptsizemultiplier</td>
 <td><a class="intref" href="#type_number"><em>number</em></a></td>
 <td>0.71</td>
-<td><span class="coreno">core&#x2716;</span></td>
+<td><span class="coreno"></span></td>
 </tr>
 
 <tr>
@@ -4929,7 +4930,7 @@ part of its rendering environment:
 <td rowspan="2" class="attname">scriptminsize</td>
 <td><a class="intref" href="#type_length"><em>length</em></a></td>
 <td>8pt</td>
-<td><span class="coreno">core&#x2716;</span></td>
+<td><span class="coreno"></span></td>
 </tr>
 
 <tr>
@@ -4944,7 +4945,7 @@ part of its rendering environment:
 <td rowspan="2" class="attname">infixlinebreakstyle</td>
 <td>"before" | "after" | "duplicate"</td>
 <td>before</td>
-<td><span class="coreno">core&#x2716;</span></td>
+<td><span class="coreno"></span></td>
 </tr>
 
 <tr>
@@ -4958,7 +4959,7 @@ part of its rendering environment:
 <td rowspan="2" class="attname">decimalpoint</td>
 <td><a class="intref" href="#type_character"><em>character</em></a></td>
 <td>.</td>
-<td><span class="coreno">core&#x2716;</span></td>
+<td><span class="coreno"></span></td>
 </tr>
 
 <tr>
@@ -5093,7 +5094,7 @@ section on &lt;mo&gt;,
 </section>
 
 <section>
- <h4 id="presm_merror">Error Message <code class="defn starttag">&lt;merror&gt;</code> <a class="coreyes" href="https://w3c.github.io/mathml-core/#dfn-merror">core&#x2714;</a></h4>
+ <h4 id="presm_merror">Error Message <code class="defn starttag">&lt;merror&gt;</code> <a class="coreyes" href="https://w3c.github.io/mathml-core/#dfn-merror"></a></h4>
 
  <section>
   <h5>Description</h5>
@@ -5182,7 +5183,7 @@ section on &lt;mo&gt;,
 
 <section>
  <h4 id="presm_mpadded">Adjust Space Around Content
- <code class="defn starttag">&lt;mpadded&gt;</code> <a class="coreyes" href="https://w3c.github.io/mathml-core/#dfn-mpadded">core&#x2714;</a></h4>
+ <code class="defn starttag">&lt;mpadded&gt;</code> <a class="coreyes" href="https://w3c.github.io/mathml-core/#dfn-mpadded"></a></h4>
 
  <section>
   <h5>Description</h5>
@@ -5239,7 +5240,7 @@ section on &lt;mo&gt;,
      | <a class="intref" href="#type_namedspace"><em>namedspace</em></a>
      )?</td>
      <td><em>same as content</em></td>
-     <td><span class="coreno">core&#x2716;</span></td>
+     <td><span class="coreno"></span></td>
     </tr>
 
     <tr>
@@ -5259,7 +5260,7 @@ section on &lt;mo&gt;,
      | <a class="intref" href="#type_namedspace"><em>namedspace</em></a>
      )?</td>
      <td><em>same as content</em></td>
-     <td><span class="coreno">core&#x2716;</span></td>
+     <td><span class="coreno"></span></td>
     </tr>
 
     <tr>
@@ -5279,7 +5280,7 @@ section on &lt;mo&gt;,
      | <a class="intref" href="#type_namedspace"><em>namedspace</em></a>
      )?</td>
      <td><em>same as content</em></td>
-     <td><span class="coreno">core&#x2716;</span></td>
+     <td><span class="coreno"></span></td>
     </tr>
 
     <tr>
@@ -5299,7 +5300,7 @@ section on &lt;mo&gt;,
      | <a class="intref" href="#type_namedspace"><em>namedspace</em></a>
      )?</td>
      <td>0em</td>
-     <td><span class="coreno">core&#x2716;</span></td>
+     <td><span class="coreno"></span></td>
     </tr>
 
     <tr>
@@ -5319,7 +5320,7 @@ section on &lt;mo&gt;,
      | <a class="intref" href="#type_namedspace"><em>namedspace</em></a>
      )?</td>
      <td>0em</td>
-     <td><span class="coreno">core&#x2716;</span></td>
+     <td><span class="coreno"></span></td>
     </tr>
 
     <tr>
@@ -5599,7 +5600,7 @@ section on &lt;mo&gt;,
 </section>
 
 <section>
- <h4 id="presm_mphantom">Making Sub-Expressions Invisible <code class="defn starttag">&lt;mphantom&gt;</code> <a class="coreyes" href="https://w3c.github.io/mathml-core/#dfn-mphantom">core&#x2714;</a></h4>
+ <h4 id="presm_mphantom">Making Sub-Expressions Invisible <code class="defn starttag">&lt;mphantom&gt;</code> <a class="coreyes" href="https://w3c.github.io/mathml-core/#dfn-mphantom"></a></h4>
 
  <section>
   <h5>Description</h5>
@@ -5741,7 +5742,7 @@ section on &lt;mo&gt;,
 
 <section>
  <h4 id="presm_mfenced">Expression Inside Pair of Fences
- <code class="defn starttag">&lt;mfenced&gt;</code> <span class="coreno">core&#x2716;</span></h4>
+ <code class="defn starttag">&lt;mfenced&gt;</code> <span class="coreno"></span></h4>
 
  <section>
   <h5>Description</h5>
@@ -5818,7 +5819,7 @@ section on &lt;mo&gt;,
      <td rowspan="2" class="attname">open</td>
      <td><a class="intref" href="#type_string"><em>string</em></a></td>
      <td>(</td>
-     <td><span class="coreno">core&#x2716;</span></td>
+     <td><span class="coreno"></span></td>
     </tr>
 
     <tr>
@@ -5833,7 +5834,7 @@ section on &lt;mo&gt;,
      <td rowspan="2" class="attname">close</td>
      <td><a class="intref" href="#type_string"><em>string</em></a></td>
      <td>)</td>
-     <td><span class="coreno">core&#x2716;</span></td>
+     <td><span class="coreno"></span></td>
     </tr>
 
     <tr>
@@ -5848,7 +5849,7 @@ section on &lt;mo&gt;,
      <td rowspan="2" class="attname">separators</td>
      <td><a class="intref" href="#type_string"><em>string</em></a></td>
      <td>,</td>
-     <td><span class="coreno">core&#x2716;</span></td>
+     <td><span class="coreno"></span></td>
     </tr>
 
     <tr>
@@ -6059,7 +6060,7 @@ section on &lt;mo&gt;,
 
 <section>
  <h4 id="presm_menclose">Enclose Expression Inside Notation
- <code class="defn starttag">&lt;menclose&gt;</code> <span class="coreno">core&#x2716;</span></h4>
+ <code class="defn starttag">&lt;menclose&gt;</code> <span class="coreno"></span></h4>
 
  <section>
   <h5>Description</h5>
@@ -6109,7 +6110,7 @@ section on &lt;mo&gt;,
      | <code class="attributevalue">madruwb</code> | text) +
      </td>
      <td>longdiv</td>
-     <td><span class="coreno">core&#x2716;</span></td>
+     <td><span class="coreno"></span></td>
     </tr>
 
     <tr>
@@ -6389,7 +6390,7 @@ section on &lt;mo&gt;,
  </p>
 
  <section>
-  <h4 id="presm_msub">Subscript <code class="defn starttag">&lt;msub&gt;</code> <a class="coreyes" href="https://w3c.github.io/mathml-core/#dfn-msub">core&#x2714;</a></h4>
+  <h4 id="presm_msub">Subscript <code class="defn starttag">&lt;msub&gt;</code> <a class="coreyes" href="https://w3c.github.io/mathml-core/#dfn-msub"></a></h4>
 
   <section>
    <h5>Description</h5>
@@ -6430,7 +6431,7 @@ section on &lt;mo&gt;,
       <td rowspan="2" class="attname">subscriptshift</td>
       <td><a class="intref" href="#type_length"><em>length</em></a></td>
       <td><em>automatic</em></td>
-      <td><span class="coreno">core&#x2716;</span></td>
+      <td><span class="coreno"></span></td>
      </tr>
 
      <tr>
@@ -6445,7 +6446,7 @@ section on &lt;mo&gt;,
  </section>
 
  <section>
-  <h4 id="presm_msup">Superscript <code class="defn starttag">&lt;msup&gt;</code> <a class="coreyes" href="https://w3c.github.io/mathml-core/#dfn-msup">core&#x2714;</a></h4>
+  <h4 id="presm_msup">Superscript <code class="defn starttag">&lt;msup&gt;</code> <a class="coreyes" href="https://w3c.github.io/mathml-core/#dfn-msup"></a></h4>
 
   <section>
    <h5>Description</h5>
@@ -6487,7 +6488,7 @@ section on &lt;mo&gt;,
       <td rowspan="2" class="attname">superscriptshift</td>
       <td><a class="intref" href="#type_length"><em>length</em></a></td>
       <td><em>automatic</em></td>
-      <td><span class="coreno">core&#x2716;</span></td>
+      <td><span class="coreno"></span></td>
      </tr>
 
      <tr>
@@ -6503,7 +6504,7 @@ section on &lt;mo&gt;,
  </section>
 
  <section>
-  <h4 id="presm_msubsup">Subscript-superscript Pair <code class="defn starttag">&lt;msubsup&gt;</code> <a class="coreyes" href="https://w3c.github.io/mathml-core/#dfn-msubsup">core&#x2714;</a></h4>
+  <h4 id="presm_msubsup">Subscript-superscript Pair <code class="defn starttag">&lt;msubsup&gt;</code> <a class="coreyes" href="https://w3c.github.io/mathml-core/#dfn-msubsup"></a></h4>
 
   <section>
    <h5>Description</h5>
@@ -6553,7 +6554,7 @@ section on &lt;mo&gt;,
       <td rowspan="2" class="attname">subscriptshift</td>
       <td><a class="intref" href="#type_length"><em>length</em></a></td>
       <td><em>automatic</em></td>
-      <td><span class="coreno">core&#x2716;</span></td>
+      <td><span class="coreno"></span></td>
      </tr>
 
      <tr>
@@ -6567,7 +6568,7 @@ section on &lt;mo&gt;,
       <td rowspan="2" class="attname">superscriptshift</td>
       <td><a class="intref" href="#type_length"><em>length</em></a></td>
       <td><em>automatic</em></td>
-      <td><span class="coreno">core&#x2716;</span></td>
+      <td><span class="coreno"></span></td>
      </tr>
 
      <tr>
@@ -6624,7 +6625,7 @@ section on &lt;mo&gt;,
  </section>
 
  <section>
-  <h4 id="presm_munder">Underscript <code class="defn starttag">&lt;munder&gt;</code> <a class="coreyes" href="https://w3c.github.io/mathml-core/#dfn-munder">core&#x2714;</a></h4>
+  <h4 id="presm_munder">Underscript <code class="defn starttag">&lt;munder&gt;</code> <a class="coreyes" href="https://w3c.github.io/mathml-core/#dfn-munder"></a></h4>
 
   <section>
    <h5>Description</h5>
@@ -6676,7 +6677,7 @@ section on &lt;mo&gt;,
       <td rowspan="2" class="attname">accentunder</td>
       <td>"true" | "false"</td>
       <td><em>automatic</em></td>
-      <td><span class="coreno">core&#x2716;</span></td>
+      <td><span class="coreno"></span></td>
      </tr>
 
      <tr>
@@ -6691,7 +6692,7 @@ section on &lt;mo&gt;,
       <td rowspan="2" class="attname">align</td>
       <td>"left" | "right" | "center"</td>
       <td>center</td>
-      <td><span class="coreno">core&#x2716;</span></td>
+      <td><span class="coreno"></span></td>
      </tr>
 
      <tr>
@@ -6761,7 +6762,7 @@ section on &lt;mo&gt;,
  </section>
 
  <section>
-  <h4 id="presm_mover">Overscript <code class="defn starttag">&lt;mover&gt;</code> <a class="coreyes" href="https://w3c.github.io/mathml-core/#dfn-mover">core&#x2714;</a></h4>
+  <h4 id="presm_mover">Overscript <code class="defn starttag">&lt;mover&gt;</code> <a class="coreyes" href="https://w3c.github.io/mathml-core/#dfn-mover"></a></h4>
 
   <section>
    <h5>Description</h5>
@@ -6813,7 +6814,7 @@ section on &lt;mo&gt;,
        <td rowspan="2" class="attname">accent</td>
        <td>"true" | "false"</td>
        <td><em>automatic</em></td>
-       <td><span class="coreno">core&#x2716;</span></td>
+       <td><span class="coreno"></span></td>
       </tr>
 
       <tr>
@@ -6828,7 +6829,7 @@ section on &lt;mo&gt;,
        <td rowspan="2" class="attname">align</td>
        <td>"left" | "right" | "center"</td>
        <td>center</td>
-       <td><span class="coreno">core&#x2716;</span></td>
+       <td><span class="coreno"></span></td>
       </tr>
 
       <tr>
@@ -6918,7 +6919,7 @@ section on &lt;mo&gt;,
 
  <section>
   <h4 id="presm_munderover">Underscript-overscript Pair
-  <code class="defn starttag">&lt;munderover&gt;</code> <a class="coreyes" href="https://w3c.github.io/mathml-core/#dfn-munderover">core&#x2714;</a></h4>
+  <code class="defn starttag">&lt;munderover&gt;</code> <a class="coreyes" href="https://w3c.github.io/mathml-core/#dfn-munderover"></a></h4>
 
   <section>
    <h5>Description</h5>
@@ -6970,7 +6971,7 @@ section on &lt;mo&gt;,
       <td rowspan="2" class="attname">accent</td>
       <td>"true" | "false"</td>
       <td><em>automatic</em></td>
-      <td><span class="coreno">core&#x2716;</span></td>
+      <td><span class="coreno"></span></td>
      </tr>
 
      <tr>
@@ -6985,7 +6986,7 @@ section on &lt;mo&gt;,
       <td rowspan="2" class="attname">accentunder</td>
       <td>"true" | "false"</td>
       <td><em>automatic</em></td>
-      <td><span class="coreno">core&#x2716;</span></td>
+      <td><span class="coreno"></span></td>
      </tr>
 
      <tr>
@@ -7000,7 +7001,7 @@ section on &lt;mo&gt;,
       <td rowspan="2" class="attname">align</td>
       <td>"left" | "right" | "center"</td>
       <td>center</td>
-      <td><span class="coreno">core&#x2716;</span></td>
+      <td><span class="coreno"></span></td>
      </tr>
 
      <tr>
@@ -7076,7 +7077,7 @@ section on &lt;mo&gt;,
   <code class="defn starttag">&lt;mmultiscripts&gt;</code><span>,
   <code class="defn emptytag">&lt;mprescripts/&gt;</code>,
   <code class="defn emptytag">&lt;none/&gt;</code></span>
-  <code class="defn starttag">&lt;munder&gt;</code> <a class="coreyes" href="https://w3c.github.io/mathml-core/#prescripts-and-tensor-indices-mmultiscripts">core&#x2714;</a>
+  <code class="defn starttag">&lt;munder&gt;</code> <a class="coreyes" href="https://w3c.github.io/mathml-core/#prescripts-and-tensor-indices-mmultiscripts"></a>
   </h4>
 
   <section>
@@ -7277,7 +7278,7 @@ section on &lt;mo&gt;,
 
  <section>
   <h4 id="presm_mtable">Table or Matrix
-  <code class="defn starttag">&lt;mtable&gt;</code> <a class="coreyes" href="https://w3c.github.io/mathml-core/#dfn-mtable">core&#x2714;</a></h4>
+  <code class="defn starttag">&lt;mtable&gt;</code> <a class="coreyes" href="https://w3c.github.io/mathml-core/#dfn-mtable"></a></h4>
 
   <section>
    <h5>Description</h5>
@@ -7340,7 +7341,7 @@ section on &lt;mo&gt;,
       <td rowspan="2" class="attname">align</td>
       <td>("top" | "bottom" | "center" | "baseline" | "axis"), <em>rownumber</em>?</td>
       <td>axis</td>
-      <td><span class="coreno">core&#x2716;</span></td>
+      <td><span class="coreno"></span></td>
      </tr>
 
      <tr>
@@ -7371,7 +7372,7 @@ section on &lt;mo&gt;,
       <td rowspan="2" class="attname">rowalign</td>
       <td>("top" | "bottom" | "center" | "baseline" | "axis") +</td>
       <td>baseline</td>
-      <td><span class="coreno">core&#x2716;</span></td>
+      <td><span class="coreno"></span></td>
      </tr>
 
      <tr>
@@ -7391,7 +7392,7 @@ section on &lt;mo&gt;,
       <td rowspan="2" class="attname">columnalign</td>
       <td>("left" | "center" | "right") +</td>
       <td>center</td>
-      <td><span class="coreno">core&#x2716;</span></td>
+      <td><span class="coreno"></span></td>
      </tr>
 
      <tr>
@@ -7409,7 +7410,7 @@ section on &lt;mo&gt;,
       <td rowspan="2" class="attname">groupalign</td>
       <td><a class="intref" href="#type_group-align"><em>group-alignment-list-list</em></a></td>
       <td>{left}</td>
-      <td><span class="coreno">core&#x2716;</span></td>
+      <td><span class="coreno"></span></td>
      </tr>
 
      <tr>
@@ -7423,7 +7424,7 @@ section on &lt;mo&gt;,
       <td rowspan="2" class="attname">alignmentscope</td>
       <td>("true" | "false") +</td>
       <td>true</td>
-      <td><span class="coreno">core&#x2716;</span></td>
+      <td><span class="coreno"></span></td>
      </tr>
 
      <tr>
@@ -7437,7 +7438,7 @@ section on &lt;mo&gt;,
       <td rowspan="2" class="attname">columnwidth</td>
       <td>("auto" | <a class="intref" href="#type_length"><em>length</em></a> | "fit") +</td>
       <td>auto</td>
-      <td><span class="coreno">core&#x2716;</span></td>
+      <td><span class="coreno"></span></td>
      </tr>
 
      <tr>
@@ -7468,7 +7469,7 @@ section on &lt;mo&gt;,
       <td rowspan="2" class="attname">width</td>
       <td>"auto" | <a class="intref" href="#type_length"><em>length</em></a></td>
       <td>auto</td>
-      <td><span class="coreno">core&#x2716;</span></td>
+      <td><span class="coreno"></span></td>
      </tr>
 
      <tr>
@@ -7492,7 +7493,7 @@ section on &lt;mo&gt;,
       <td rowspan="2" class="attname">rowspacing</td>
       <td>(<a class="intref" href="#type_length"><em>length</em></a>) +</td>
       <td>1.0ex</td>
-      <td><span class="coreno">core&#x2716;</span></td>
+      <td><span class="coreno"></span></td>
      </tr>
 
      <tr>
@@ -7506,7 +7507,7 @@ section on &lt;mo&gt;,
       <td rowspan="2" class="attname">columnspacing</td>
       <td>(<a class="intref" href="#type_length"><em>length</em></a>) +</td>
       <td>0.8em</td>
-      <td><span class="coreno">core&#x2716;</span></td>
+      <td><span class="coreno"></span></td>
      </tr>
 
      <tr>
@@ -7520,7 +7521,7 @@ section on &lt;mo&gt;,
       <td rowspan="2" class="attname">rowlines</td>
       <td>("none" | "solid" | "dashed") +</td>
       <td>none</td>
-      <td><span class="coreno">core&#x2716;</span></td>
+      <td><span class="coreno"></span></td>
      </tr>
 
      <tr>
@@ -7537,7 +7538,7 @@ section on &lt;mo&gt;,
       <td rowspan="2" class="attname">columnlines</td>
       <td>("none" | "solid" | "dashed") +</td>
       <td>none</td>
-      <td><span class="coreno">core&#x2716;</span></td>
+      <td><span class="coreno"></span></td>
      </tr>
 
      <tr>
@@ -7554,7 +7555,7 @@ section on &lt;mo&gt;,
       <td rowspan="2" class="attname">frame</td>
       <td>"none" | "solid" | "dashed"</td>
       <td>none</td>
-      <td><span class="coreno">core&#x2716;</span></td>
+      <td><span class="coreno"></span></td>
      </tr>
 
      <tr>
@@ -7570,7 +7571,7 @@ section on &lt;mo&gt;,
       <td rowspan="2" class="attname">framespacing</td>
       <td><a class="intref" href="#type_length"><em>length</em></a>, <a class="intref" href="#type_length"><em>length</em></a></td>
       <td>0.4em 0.5ex</td>
-      <td><span class="coreno">core&#x2716;</span></td>
+      <td><span class="coreno"></span></td>
      </tr>
 
      <tr>
@@ -7586,7 +7587,7 @@ section on &lt;mo&gt;,
       <td rowspan="2" class="attname">equalrows</td>
       <td>"true" | "false"</td>
       <td>false</td>
-      <td><span class="coreno">core&#x2716;</span></td>
+      <td><span class="coreno"></span></td>
      </tr>
 
      <tr>
@@ -7599,7 +7600,7 @@ section on &lt;mo&gt;,
       <td rowspan="2" class="attname">equalcolumns</td>
       <td>"true" | "false"</td>
       <td>false</td>
-      <td><span class="coreno">core&#x2716;</span></td>
+      <td><span class="coreno"></span></td>
      </tr>
 
      <tr>
@@ -7612,7 +7613,7 @@ section on &lt;mo&gt;,
       <td rowspan="2" class="attname">displaystyle</td>
       <td>"true" | "false"</td>
       <td>false</td>
-      <td><span class="coreno">core&#x2716;</span></td>
+      <td><span class="coreno"></span></td>
      </tr>
 
      <tr>
@@ -7627,7 +7628,7 @@ section on &lt;mo&gt;,
       <td rowspan="2" class="attname">side</td>
       <td>"left" | "right" | "leftoverlap" | "rightoverlap"</td>
       <td>right</td>
-      <td><span class="coreno">core&#x2716;</span></td>
+      <td><span class="coreno"></span></td>
      </tr>
 
      <tr>
@@ -7646,7 +7647,7 @@ section on &lt;mo&gt;,
       <td rowspan="2" class="attname">minlabelspacing</td>
       <td><a class="intref" href="#type_length"><em>length</em></a></td>
       <td>0.8em</td>
-      <td><span class="coreno">core&#x2716;</span></td>
+      <td><span class="coreno"></span></td>
      </tr>
 
      <tr>
@@ -7728,7 +7729,7 @@ section on &lt;mo&gt;,
  </section>
 
  <section>
-  <h4 id="presm_mtr">Row in Table or Matrix <code class="defn starttag">&lt;mtr&gt;</code> <a class="coreyes" href="https://w3c.github.io/mathml-core/#dfn-mtr">core&#x2714;</a></h4>
+  <h4 id="presm_mtr">Row in Table or Matrix <code class="defn starttag">&lt;mtr&gt;</code> <a class="coreyes" href="https://w3c.github.io/mathml-core/#dfn-mtr"></a></h4>
 
   <section>
    <h5>Description</h5>
@@ -7772,7 +7773,7 @@ section on &lt;mo&gt;,
       <td rowspan="2" class="attname">rowalign</td>
       <td>"top" | "bottom" | "center" | "baseline" | "axis"</td>
       <td><em>inherited</em></td>
-      <td><span class="coreno">core&#x2716;</span></td>
+      <td><span class="coreno"></span></td>
      </tr>
 
      <tr>
@@ -7786,7 +7787,7 @@ section on &lt;mo&gt;,
       <td rowspan="2" class="attname">columnalign</td>
       <td>("left" | "center" | "right") +</td>
       <td><em>inherited</em></td>
-      <td><span class="coreno">core&#x2716;</span></td>
+      <td><span class="coreno"></span></td>
      </tr>
 
      <tr>
@@ -7800,7 +7801,7 @@ section on &lt;mo&gt;,
       <td rowspan="2" class="attname">groupalign</td>
       <td><a class="intref" href="#type_group-align"><em>group-alignment-list-list</em></a></td>
       <td><em>inherited</em></td>
-      <td><span class="coreno">core&#x2716;</span></td>
+      <td><span class="coreno"></span></td>
      </tr>
 
      <tr>
@@ -7816,7 +7817,7 @@ section on &lt;mo&gt;,
 
  <section>
   <h4 id="presm_mlabeledtr">Labeled Row in Table or Matrix
-  <code class="defn starttag">&lt;mlabeledtr&gt;</code> <span class="coreno">core&#x2716;</span></h4>
+  <code class="defn starttag">&lt;mlabeledtr&gt;</code> <span class="coreno"></span></h4>
 
   <section>
    <h5>Description</h5>
@@ -7965,7 +7966,7 @@ section on &lt;mo&gt;,
  </section>
 
  <section>
-  <h4 id="presm_mtd">Entry in Table or Matrix <code class="defn starttag">&lt;mtd&gt;</code> <a class="coreyes" href="https://w3c.github.io/mathml-core/#dfn-mtd">core&#x2714;</a></h4>
+  <h4 id="presm_mtd">Entry in Table or Matrix <code class="defn starttag">&lt;mtd&gt;</code> <a class="coreyes" href="https://w3c.github.io/mathml-core/#dfn-mtd"></a></h4>
 
   <section>
    <h5>Description</h5>
@@ -8004,7 +8005,7 @@ section on &lt;mo&gt;,
       <td rowspan="2" class="attname">rowspan</td>
       <td><a class="intref" href="#type_positive-integer"><em>positive-integer</em></a></td>
       <td>1</td>
-      <td><span class="coreno">core&#x2716;</span></td>
+      <td><span class="coreno"></span></td>
      </tr>
 
      <tr>
@@ -8019,7 +8020,7 @@ section on &lt;mo&gt;,
       <td rowspan="2" class="attname">columnspan</td>
       <td><a class="intref" href="#type_positive-integer"><em>positive-integer</em></a></td>
       <td>1</td>
-      <td><span class="coreno">core&#x2716;</span></td>
+      <td><span class="coreno"></span></td>
      </tr>
 
      <tr>
@@ -8034,7 +8035,7 @@ section on &lt;mo&gt;,
       <td rowspan="2" class="attname">rowalign</td>
       <td>"top" | "bottom" | "center" | "baseline" | "axis"</td>
       <td><em>inherited</em></td>
-      <td><span class="coreno">core&#x2716;</span></td>
+      <td><span class="coreno"></span></td>
      </tr>
 
      <tr>
@@ -8049,7 +8050,7 @@ section on &lt;mo&gt;,
       <td rowspan="2" class="attname">columnalign</td>
       <td>"left" | "center" | "right"</td>
       <td><em>inherited</em></td>
-      <td><span class="coreno">core&#x2716;</span></td>
+      <td><span class="coreno"></span></td>
      </tr>
 
      <tr>
@@ -8064,7 +8065,7 @@ section on &lt;mo&gt;,
       <td rowspan="2" class="attname">groupalign</td>
       <td><a class="intref" href="#type_group-align"><em>group-alignment-list</em></a></td>
       <td><em>inherited</em></td>
-      <td><span class="coreno">core&#x2716;</span></td>
+      <td><span class="coreno"></span></td>
      </tr>
 
      <tr>
@@ -8089,7 +8090,7 @@ section on &lt;mo&gt;,
 
  <section>
   <h4 id="presm_malign">Alignment Markers
-  <code class="emptytag">&lt;maligngroup/&gt;</code>, <code class="emptytag">&lt;malignmark/&gt;</code> <span class="coreno">core&#x2716;</span></h4>
+  <code class="emptytag">&lt;maligngroup/&gt;</code>, <code class="emptytag">&lt;malignmark/&gt;</code> <span class="coreno"></span></h4>
 
   <section>
    <h5>Description</h5>
@@ -8433,7 +8434,7 @@ section on &lt;mo&gt;,
       <td rowspan="2" class="attname">edge</td>
       <td>"left" | "right"</td>
       <td>left</td>
-      <td><span class="coreno">core&#x2716;</span></td>
+      <td><span class="coreno"></span></td>
      </tr>
 
      <tr>
@@ -8515,7 +8516,7 @@ section on &lt;mo&gt;,
       <td rowspan="2" class="attname">groupalign</td>
       <td>"left" | "center" | "right" | "decimalpoint"</td>
       <td><em>inherited</em></td>
-      <td><span class="coreno">core&#x2716;</span></td>
+      <td><span class="coreno"></span></td>
      </tr>
 
      <tr>
@@ -9041,7 +9042,7 @@ these elements can be used to represent several notations used for repeating dec
 <p> Many more examples are given in <a href="#presm_elemmath_examples"></a>.</p>
 
 <section>
-<h4 id="presm_mstack">Stacks of Characters <code class="defn starttag">&lt;mstack&gt;</code> <span class="coreno">core&#x2716;</span></h4>
+<h4 id="presm_mstack">Stacks of Characters <code class="defn starttag">&lt;mstack&gt;</code> <span class="coreno"></span></h4>
 
 <section>
 <h5>Description</h5>
@@ -9116,7 +9117,7 @@ the <code class="attribute">charalign</code> attribute.</p>
 </section>
 
 <section>
-<h4 id="presm_mlongdiv">Long Division <code class="defn starttag">&lt;mlongdiv&gt;</code> <span class="coreno">core&#x2716;</span></h4>
+<h4 id="presm_mlongdiv">Long Division <code class="defn starttag">&lt;mlongdiv&gt;</code> <span class="coreno"></span></h4>
 
 <section>
 <h5>Description</h5>
@@ -9182,7 +9183,7 @@ by
 
 "stackedleftlinetop" </td>
 <td>lefttop</td>
-<td><span class="coreno">core&#x2716;</span></td>
+<td><span class="coreno"></span></td>
 </tr>
 
 <tr>
@@ -9255,7 +9256,7 @@ for long division notations in different countries around the world:</p>
 </section>
 
 <section>
-<h4 id="presm_msgroup">Group Rows with Similiar Positions <code class="defn starttag">&lt;msgroup&gt;</code> <span class="coreno">core&#x2716;</span></h4>
+<h4 id="presm_msgroup">Group Rows with Similiar Positions <code class="defn starttag">&lt;msgroup&gt;</code> <span class="coreno"></span></h4>
 
 <section>
 <h5>Description</h5>
@@ -9292,7 +9293,7 @@ below in addition to those specified in <a href="#presm_presatt"></a>.</p>
 <td rowspan="2" class="attname">position</td>
 <td><a class="intref" href="#type_integer"><em>integer</em></a></td>
 <td>0</td>
-<td><span class="coreno">core&#x2716;</span></td>
+<td><span class="coreno"></span></td>
 </tr>
 
 <tr>
@@ -9315,7 +9316,7 @@ below in addition to those specified in <a href="#presm_presatt"></a>.</p>
 <td rowspan="2" class="attname">shift</td>
 <td><a class="intref" href="#type_integer"><em>integer</em></a></td>
 <td>0</td>
-<td><span class="coreno">core&#x2716;</span></td>
+<td><span class="coreno"></span></td>
 </tr>
 
 <tr>
@@ -9332,7 +9333,7 @@ below in addition to those specified in <a href="#presm_presatt"></a>.</p>
 </section>
 
 <section>
-<h4 id="presm_msrow">Rows in Elementary Math <code class="defn starttag">&lt;msrow&gt;</code> <span class="coreno">core&#x2716;</span></h4>
+<h4 id="presm_msrow">Rows in Elementary Math <code class="defn starttag">&lt;msrow&gt;</code> <span class="coreno"></span></h4>
 
 <section>
 <h5>Description</h5>
@@ -9389,7 +9390,7 @@ below in addition to those specified in <a href="#presm_presatt"></a>.</p>
 <td rowspan="2" class="attname">position</td>
 <td><a class="intref" href="#type_integer"><em>integer</em></a></td>
 <td>0</td>
-<td><span class="coreno">core&#x2716;</span></td>
+<td><span class="coreno"></span></td>
 </tr>
 
 <tr>
@@ -9413,7 +9414,7 @@ below in addition to those specified in <a href="#presm_presatt"></a>.</p>
 </section>
 
 <section>
-<h4 id="presm_mscarries">Carries, Borrows, and Crossouts <code class="defn starttag">&lt;mscarries&gt;</code> <span class="coreno">core&#x2716;</span></h4>
+<h4 id="presm_mscarries">Carries, Borrows, and Crossouts <code class="defn starttag">&lt;mscarries&gt;</code> <span class="coreno"></span></h4>
 
 <section>
 <h5>Description</h5>
@@ -9478,7 +9479,7 @@ below in addition to those specified in <a href="#presm_presatt"></a>.</p>
 <td rowspan="2" class="attname">position</td>
 <td><a class="intref" href="#type_integer"><em>integer</em></a></td>
 <td>0</td>
-<td><span class="coreno">core&#x2716;</span></td>
+<td><span class="coreno"></span></td>
 </tr>
 
 <tr>
@@ -9498,7 +9499,7 @@ below in addition to those specified in <a href="#presm_presatt"></a>.</p>
 <td rowspan="2" class="attname">location</td>
 <td>"w" | "nw" | "n" | "ne" | "e" | "se" | "s" | "sw" </td>
 <td>n</td>
-<td><span class="coreno">core&#x2716;</span></td>
+<td><span class="coreno"></span></td>
 </tr>
 
 <tr>
@@ -9515,7 +9516,7 @@ below in addition to those specified in <a href="#presm_presatt"></a>.</p>
 <td>("none" | "updiagonalstrike" | "downdiagonalstrike" | "verticalstrike" | "horizontalstrike")*
 </td>
 <td>none</td>
-<td><span class="coreno">core&#x2716;</span></td>
+<td><span class="coreno"></span></td>
 </tr>
 
 <tr>
@@ -9534,7 +9535,7 @@ below in addition to those specified in <a href="#presm_presatt"></a>.</p>
 <td rowspan="2" class="attname">scriptsizemultiplier</td>
 <td> <a class="intref" href="#type_number"><em>number</em></a></td>
 <td><em>inherited (0.6)</em></td>
-<td><span class="coreno">core&#x2716;</span></td>
+<td><span class="coreno"></span></td>
 </tr>
 
 <tr>
@@ -9549,7 +9550,7 @@ below in addition to those specified in <a href="#presm_presatt"></a>.</p>
 </section>
 
 <section>
-<h4 id="presm_mscarry">A Single Carry <code class="defn starttag">&lt;mscarry&gt;</code> <span class="coreno">core&#x2716;</span></h4>
+<h4 id="presm_mscarry">A Single Carry <code class="defn starttag">&lt;mscarry&gt;</code> <span class="coreno"></span></h4>
 
 <section>
 <h5>Description</h5>
@@ -9592,7 +9593,7 @@ below in addition to those specified in <a href="#presm_presatt"></a>.</p>
 <td rowspan="2" class="attname">location</td>
 <td>"w" | "nw" | "n" | "ne" | "e" | "se" | "s" | "sw"</td>
 <td><em>inherited</em></td>
-<td><span class="coreno">core&#x2716;</span></td>
+<td><span class="coreno"></span></td>
 </tr>
 
 <tr>
@@ -9608,7 +9609,7 @@ below in addition to those specified in <a href="#presm_presatt"></a>.</p>
 <td>("none" | "updiagonalstrike" | "downdiagonalstrike" | "verticalstrike" | "horizontalstrike")*
 </td>
 <td><em>inherited</em></td>
-<td><span class="coreno">core&#x2716;</span></td>
+<td><span class="coreno"></span></td>
 </tr>
 
 <tr>
@@ -9625,7 +9626,7 @@ below in addition to those specified in <a href="#presm_presatt"></a>.</p>
 </section>
 
 <section>
-<h4 id="presm_msline">Horizontal Line <code class="defn emptytag">&lt;msline/&gt;</code> <span class="coreno">core&#x2716;</span></h4>
+<h4 id="presm_msline">Horizontal Line <code class="defn emptytag">&lt;msline/&gt;</code> <span class="coreno"></span></h4>
 
 <section>
 <h5>Description</h5>
@@ -9662,7 +9663,7 @@ The line should be drawn using the color specified by <code class="attribute">ma
 <td rowspan="2" class="attname">position</td>
 <td><a class="intref" href="#type_integer"><em>integer</em></a></td>
 <td>0</td>
-<td><span class="coreno">core&#x2716;</span></td>
+<td><span class="coreno"></span></td>
 </tr>
 
 <tr>
@@ -9684,7 +9685,7 @@ The line should be drawn using the color specified by <code class="attribute">ma
 <td rowspan="2" class="attname">length</td>
 <td><a class="intref" href="#type_unsigned-integer"><em>unsigned-integer</em></a></td>
 <td>0</td>
-<td><span class="coreno">core&#x2716;</span></td>
+<td><span class="coreno"></span></td>
 </tr>
 
 <tr>
@@ -9699,7 +9700,7 @@ The line should be drawn using the color specified by <code class="attribute">ma
 <td rowspan="2" class="attname">leftoverhang</td>
 <td><a class="intref" href="#type_length"><em>length</em></a></td>
 <td>0</td>
-<td><span class="coreno">core&#x2716;</span></td>
+<td><span class="coreno"></span></td>
 </tr>
 
 <tr>
@@ -9713,7 +9714,7 @@ The line should be drawn using the color specified by <code class="attribute">ma
 <td rowspan="2" class="attname">rightoverhang</td>
 <td><a class="intref" href="#type_length"><em>length</em></a></td>
 <td>0</td>
-<td><span class="coreno">core&#x2716;</span></td>
+<td><span class="coreno"></span></td>
 </tr>
 
 <tr>
@@ -9727,7 +9728,7 @@ The line should be drawn using the color specified by <code class="attribute">ma
 <td rowspan="2" class="attname">mslinethickness</td>
 <td><a class="intref" href="#type_length"><em>length</em></a> | "thin" | "medium" | "thick"</td>
 <td>medium</td>
-<td><span class="coreno">core&#x2716;</span></td>
+<td><span class="coreno"></span></td>
 </tr>
 
 <tr>
@@ -10237,7 +10238,7 @@ below.</p>
 
  <section>
   <h4 id="presm_maction">Bind Action to Sub-Expression
-  <code class="defn starttag">&lt;maction&gt;</code> <a class="coreyes" href="https://w3c.github.io/mathml-core/#dfn-maction">core&#x2714;</a></h4>
+  <code class="defn starttag">&lt;maction&gt;</code> <a class="coreyes" href="https://w3c.github.io/mathml-core/#dfn-maction"></a></h4>
 
   <p>To provide a mechanism for binding actions to expressions, MathML
   provides the <code class="element">maction</code> element. This element accepts any
@@ -10282,7 +10283,7 @@ error; the appropriate rendering in that case is as described in
    <td rowspan="2" class="attname">actiontype</td>
    <td><a class="intref" href="#type_string"><em>string</em></a></td>
    <td><em>required</em></td>
-   <td><span class="coreno">core&#x2716;</span></td>
+   <td><span class="coreno"></span></td>
   </tr>
 
   <tr>
@@ -10297,7 +10298,7 @@ error; the appropriate rendering in that case is as described in
 <td rowspan="2" class="attname">selection</td>
 <td><a class="intref" href="#type_positive-integer"><em>positive-integer</em></a></td>
 <td>1</td>
-<td><span class="coreno">core&#x2716;</span></td>
+<td><span class="coreno"></span></td>
 </tr>
 
 <tr>


### PR DESCRIPTION
This PR removes the explicit `core✔` and `core✖` from the heading content in chapter 3 and then adds them back via CSS `content:`  properties for `coreyes` and `coreno` classes. In particular this means that they do not appear in automated link text when referencing a section.