### PR TITLE
compress length description

### DIFF
--- a/src/fundamentals.html
+++ b/src/fundamentals.html
@@ -206,12 +206,12 @@
       </tr>
 
       <tr>
-       <td><dfn><em>length</em></dfn></td>
+       <td id="type_length"><dfn><em>length</em></dfn></td>
        <td>a length, as explained below, <a href="#fund_units"></a></td>
       </tr>
        
       <tr>
-       <td><dfn><em>namedlength</em></dfn></td>
+       <td id="type_namedspace"><dfn><em>namedspace</em></dfn></td>
        <td>a named length, as explained below, <a href="#fund_units"></a></td>
       </tr>
 
@@ -367,49 +367,63 @@
 
 
     <p>
-     The available units are extended with a set of [=named-lengths=]
-     that name multiples of 1/18&#x2009;em as described below.
-     In addition, the attributes on <code class="element">mpadded</code> allow three extra named lengths, <code>height</code>, <code>depth</code> and <code>width</code> denoting the original dimensions of the content.
+     The available values are extended with a set of [=named-lengths=]
+     that name multiples of 1/18&#x2009;em as described below.  In
+     addition, the attributes on <code class="element">mpadded</code>
+     allow three <dfn>psuedo-units</dfn>, <code>height</code>,
+     <code>depth</code> and <code>width</code> denoting the original
+     dimensions of the content.
     </p>
-    <p>MathML also allows lengths to be specifed as
-     a number without a unit. This  is intepreted as a multiple of the
-     reference value.
-     This form is primarily for backward compatibility and should be avoided,
-     preferring explicit units (or <code>%</code> values) for clarity.
+    <p>MathML&#160;3 also allowed a deprecated usage with lengths specifed as
+     a number without a unit. This  was intepreted as a multiple of the
+     reference value. This form is considered invalid in MathML&#160;4.
     </p>
 
-    <p><dfn>named-lengths</dfn> that may be used as units in
-    [=length=] expressions, and their value:
+    <p><dfn>named-lengths</dfn> that may be used as the value of a
+    [=length=] expressions, and their value:</p>
 
-       <span style="white-space:nowrap"><code class="attributevalue">veryverythinmathspace</code> =
-       1/18&#x2009;em</span>,
-       <span style="white-space:nowrap"><code class="attributevalue">verythinmathspace</code> =
-       2/18&#x2009;em</span>,
-       <span style="white-space:nowrap"><code class="attributevalue">thinmathspace</code> =
-       3/18&#x2009;em</span>,
-       <span style="white-space:nowrap"><code class="attributevalue">mediummathspace</code> =
-       4/18&#x2009;em</span>,
-       <span style="white-space:nowrap"><code class="attributevalue">thickmathspace</code> =
-       5/18&#x2009;em</span>,
-       <span style="white-space:nowrap"><code class="attributevalue">verythickmathspace</code> =
-       6/18&#x2009;em</span>,
-       <span style="white-space:nowrap"><code class="attributevalue">veryverythickmathspace</code> =
-       7/18&#x2009;em</span>,
-       <span style="white-space:nowrap"><code class="attributevalue">negativeveryverythinmathspace</code> =
-       &#x2212;1/18&#x2009;em</span>,
-       <span style="white-space:nowrap"><code class="attributevalue">negativeverythinmathspace</code> =
-       &#x2212;2/18&#x2009;em</span>,
-       <span style="white-space:nowrap"><code class="attributevalue">negativethinmathspace</code> =
-       &#x2212;3/18&#x2009;em</span>,
-       <span style="white-space:nowrap"><code class="attributevalue">negativemediummathspace</code> =
-       &#x2212;4/18&#x2009;em</span>,
-       <span style="white-space:nowrap"><code class="attributevalue">negativethickmathspace</code> =
-       &#x2212;5/18&#x2009;em</span>,
-       <span style="white-space:nowrap"><code class="attributevalue">negativeverythickmathspace</code> =
-       &#x2212;6/18&#x2009;em</span>,
-       <span style="white-space:nowrap"><code class="attributevalue">negativeveryverythickmathspace</code> =
-       &#x2212;7/18&#x2009;em</span>.
-    </p>
+      <table border="1">
+       <thead>
+	<tr><th>Positive space</th><th>Negative space</th><th>Value</th></tr>
+	</thead>
+	<tbody>
+	 <tr>
+	  <td style="white-space:nowrap"><code class="attributevalue">veryverythinmathspace</code></td>
+	  <td style="white-space:nowrap"><code class="attributevalue">negativeveryverythinmathspace</code></td>
+	  <td>±1/18&#x2009;em</td>
+	 </tr>
+	 <tr>
+	  <td style="white-space:nowrap"><code class="attributevalue">verythinmathspace</code></td>
+	  <td style="white-space:nowrap"><code class="attributevalue">negativeverythinmathspace</code></td>
+	  <td>±2/18&#x2009;em</td>
+	 </tr>
+	 <tr>
+	  <td style="white-space:nowrap"><code class="attributevalue">thinmathspace</code></td>
+	  <td style="white-space:nowrap"><code class="attributevalue">negativethinmathspace</code></td>
+	  <td>±3/18&#x2009;em</td>
+	 </tr>
+	 <tr>
+	  <td style="white-space:nowrap"><code class="attributevalue">mediummathspace</code></td>
+	  <td style="white-space:nowrap"><code class="attributevalue">negativemediummathspace</code></td>
+	  <td>±4/18&#x2009;em</td>
+	 </tr>
+	 <tr>
+	  <td style="white-space:nowrap"><code class="attributevalue">thickmathspace</code></td>
+	  <td style="white-space:nowrap"><code class="attributevalue">negativethickmathspace</code></td>
+	  <td>±5/18&#x2009;em</td>
+	 </tr>
+	 <tr>
+	  <td style="white-space:nowrap"><code class="attributevalue">verythickmathspace</code></td>
+	  <td style="white-space:nowrap"><code class="attributevalue">negativeverythickmathspace</code></td>
+	  <td>±6/18&#x2009;em</td>
+	 </tr>
+	 <tr>
+	  <td style="white-space:nowrap"><code class="attributevalue">veryverythickmathspace</code></td>
+	  <td style="white-space:nowrap"><code class="attributevalue">negativeveryverythickmathspace</code></td>
+	  <td>±7/18&#x2009;em</td>
+	 </tr>
+	</tbody>
+      </table>
 
     <section>
      <h6 id="units_addl_notes">Additional notes about units</h6>

--- a/src/fundamentals.html
+++ b/src/fundamentals.html
@@ -145,7 +145,7 @@
     used for most attributes in the present document.</p>
 
 
-    <table border="1" id="fund_table-attval">
+    <table id="fund_table-attval" class="data">
 
      <thead>
 
@@ -271,7 +271,7 @@
      The combining operators are shown in order of precedence from highest
     to lowest:</p>
 
-    <table id="fund_table_notn" border="1">
+    <table id="fund_table_notn" class="data">
 
      <thead>
 
@@ -379,10 +379,10 @@
      reference value. This form is considered invalid in MathML&#160;4.
     </p>
 
-    <p><dfn>named-lengths</dfn> that may be used as the value of a
+    <p>The <dfn>named-lengths</dfn> that may be used as the value of a
     [=length=] expressions, and their value:</p>
 
-      <table border="1">
+      <table class="data">
        <thead>
 	<tr><th>Positive space</th><th>Negative space</th><th>Value</th></tr>
 	</thead>

--- a/src/fundamentals.html
+++ b/src/fundamentals.html
@@ -19,7 +19,7 @@
    and how they may be contained within each other,
    as well as additional syntactic rules for the values of attributes.
    These rules are defined by this specification,
-   and formalized by a RelaxNG schema  [[RELAXNG-SCHEMA]]] in <a href="#parsing"></a>.
+   and formalized by a RelaxNG schema  [[RELAXNG-SCHEMA]] in <a href="#parsing"></a>.
    Derived schema in other formats, DTD (Document Type Definition)
    and  XML Schema [[XMLSchemas]] are also provided.
    </p>
@@ -42,11 +42,11 @@
    <p>An XML namespace [[Namespaces]] is a collection of names identified by a URI.
    The URI for the MathML namespace is:</p>
 
-   <div class="example ">
+
     <pre>
      http://www.w3.org/1998/Math/MathML
     </pre>
-   </div>
+
 
    <p>To declare a namespace when using the XML serialisation of MathML,
    one uses an <code class="attribute">xmlns</code>
@@ -157,50 +157,41 @@
 
      <tbody>
 
+
       <tr>
-       <td id="type_digit"><em>decimal-digit</em></td>
-       <td>a decimal digit from the range U+0030 to U+0039</td>
+       <td id="type_unsigned-integer"><dfn><em>unsigned-integer</em></dfn></td>
+       <td>As defined in [[MathML-Core]], an <a data-cite="CSS-VALUES-3#integer-value"><code>integer</code></a>, whose first character is neither
+              U+002D HYPHEN-MINUS character (-) nor
+              U+002B PLUS SIGN (+).</td>
       </tr>
 
       <tr>
-       <td id="type_hexdigit"><em>hexadecimal-digit</em></td>
-       <td>a hexadecimal (base 16) digit from the ranges U+0030 to U+0039, U+0041 to
-       U+0046 and  U+0061 to U+0066</td>
+       <td id="type_positive-integer"><dfn><em>positive-integer</em></dfn></td>
+       <td>An [=unsigned-integer=] not consisting solely of "0"s (U+0030), representing a positive integer</td>
       </tr>
 
       <tr>
-       <td id="type_unsigned-integer"><em>unsigned-integer</em></td>
-       <td>a string of <a class="intref" href="#type_digit"><em>decimal-digit</em></a>s,
-       representing a non-negative integer</td>
-      </tr>
-
-      <tr>
-       <td id="type_positive-integer"><em>positive-integer</em></td>
-       <td>a string of <a class="intref" href="#type_digit"><em>decimal-digit</em></a>s,
-       but not consisting solely of "0"s (U+0030), representing a positive integer</td>
-      </tr>
-
-      <tr>
-       <td id="type_integer"><em>integer</em></td>
-       <td>an optional "-"  (U+002D), followed by a string of
-       <a class="intref" href="#type_digit"><em>decimal digit</em></a>s,
+       <td id="type_integer"><dfn><em>integer</em></dfn></td>
+       <td>an optional "-"  (U+002D), followed by an [=unsigned-integer=],
        and representing an integer
        </td>
       </tr>
 
       <tr>
-       <td id="type_unsigned-number"><em>unsigned-number</em></td>
+       <td id="type_unsigned-number"><dfn><em>unsigned-number</em></dfn></td>
        <td>
-        a string of <a class="intref" href="#type_digit"><em>decimal digit</em></a>s
-        with up to one decimal point (U+002E),
-        representing a non-negative terminating decimal number
+         value as defined in
+              [[CSS-VALUES-3]] <a data-cite="CSS-VALUES-3#number"><code>number</code></a>, whose first character is neither
+              U+002D HYPHEN-MINUS character (-) nor
+              U+002B PLUS SIGN (+),
+              representing a non-negative terminating decimal number
        (a type of rational number)</td>
       </tr>
 
       <tr>
        <td id="type_number"><em>number</em></td>
        <td>
-        an optional prefix of "-" (U+002D), followed by an unsigned number,
+        an optional prefix of "-" (U+002D), followed by an [=unsigned number=],
        representing a terminating decimal number (a type of rational number)</td>
       </tr>
 
@@ -215,23 +206,14 @@
       </tr>
 
       <tr>
-       <td><em>length</em></td>
+       <td><dfn><em>length</em></dfn></td>
        <td>a length, as explained below, <a href="#fund_units"></a></td>
       </tr>
 
-      <tr>
-       <td><em>unit</em></td>
-       <td>a unit, typically used as part of a length, as explained below, <a href="#fund_units"></a></td>
-      </tr>
-
-      <tr>
-       <td><em>namedlength</em></td>
-       <td>a named length, as explained below, <a href="#fund_units"></a></td>
-      </tr>
 
       <tr>
        <td id="type_color"><em>color</em></td>
-       <td>a color, using the sytax specified by [[css-color-3]]</td>
+       <td>a color, using the syntax specified by [[css-color-3]]</td>
       </tr>
 
       <tr>
@@ -303,12 +285,12 @@
       </tr>
 
       <tr>
-       <td><em>f</em><code>?</code></td>
+       <td><em>f</em> ?</td>
        <td>an optional instance of <em>f</em></td>
       </tr>
 
       <tr>
-       <td><em>f</em> <code>*</code></td>
+       <td><em>f</em> *</td>
        <td>zero or more instances of <em>f</em>, with
        separating whitespace characters</td>
       </tr>
@@ -371,139 +353,63 @@
    <section>
     <h5 id="fund_units">Length Valued Attributes</h5>
 
-    <p id="type_length">Most presentation elements have attributes that accept values
+    <p>Most presentation elements have attributes that accept values
     representing lengths to be used for size, spacing or similar
     properties.  The
     basic <a id="type_unit" data-cite="CSS-VALUES-3#typedef-length-percentage"><code>&lt;length-percentage&gt;</code></a>
     syntax is defined in [[CSS-VALUES-3]]. This is the only length
     syntax that may be used in [[MathML-Core]].  However this
-    specification defines additional syntax for specific attributes as
-    decribed below and in the entry for each affected attribute.</p>
+    specification defines additional syntax.</p>
 
 
     <p>
-     A trailing "%" represents a percent of
-     a reference value; unless otherwise stated,
-     the reference value is
-     the default value.
-     The default value, or how it is obtained,
-     is listed in the table of attributes for each element
-     along with the reference value when
-     it differs from the default.
-     (See also <a href="#fund_defaults"></a>.)
-     A number without a unit is intepreted as a multiple of the
+     The available units are extended with a set of [=named-lengths=]
+     that name multiples of 1/18&#x2009;em as described below.
+     In addition, the attributes on <code class="element">mpadded</code> allow three extra named lengths, <code>height</code>, <code>depth</code> and <code>width</code> denoting the original dimensions of the content.
+    </p>
+    <p>MathML also allows lengths to be specifed as
+     a number without a unit. This  is intepreted as a multiple of the
      reference value.
      This form is primarily for backward compatibility and should be avoided,
-     prefering explicit units for clarity.
+     preferring explicit units (or <code>%</code> values) for clarity.
     </p>
 
-    <p>In some cases, the range of acceptable values for a particular attribute may be restricted;
-    implementations are free to round up or down to the closest allowable value.</p>
+    <p><dfn>named-lengths</dfn> that may be used as units in
+    [=length=] expressions, and their value:
 
-
-
-
-    <p id="type_namedspace">The following constants, <em>namedspace</em>s,
-    may also be used where a length is needed; they are typically used for
-    spacing or padding between tokens.
-
-    <div class="note">Mandate these rather than leave as implementation defined?</div>
-    Recommended default values for these constants are shown;
-    the actual spacing used is implementation specific.
-
-    <table border="1">
-
-     <thead>
-
-      <tr>
-       <td><em>namedspace</em></td>
-       <td>Recommended default</td>
-      </tr>
-     </thead>
-
-     <tbody>
-
-      <tr>
-       <td><code class="attributevalue">veryverythinmathspace</code></td>
-       <td>1/18<code>em</code></td>
-      </tr>
-
-      <tr>
-       <td><code class="attributevalue">verythinmathspace</code></td>
-       <td>2/18<code>em</code></td>
-      </tr>
-
-      <tr>
-       <td><code class="attributevalue">thinmathspace</code></td>
-       <td>3/18<code>em</code></td>
-      </tr>
-
-      <tr>
-       <td><code class="attributevalue">mediummathspace</code></td>
-       <td>4/18<code>em</code></td>
-      </tr>
-
-      <tr>
-       <td><code class="attributevalue">thickmathspace</code></td>
-       <td>5/18<code>em</code></td>
-      </tr>
-
-      <tr>
-       <td><code class="attributevalue">verythickmathspace</code></td>
-       <td>6/18<code>em</code></td>
-      </tr>
-
-      <tr>
-       <td><code class="attributevalue">veryverythickmathspace</code></td>
-       <td>7/18<code>em</code></td>
-      </tr>
-
-      <tr>
-       <td><code class="attributevalue">negativeveryverythinmathspace</code></td>
-       <td>-1/18<code>em</code></td>
-      </tr>
-
-      <tr>
-       <td><code class="attributevalue">negativeverythinmathspace</code></td>
-       <td>-2/18<code>em</code></td>
-      </tr>
-
-      <tr>
-       <td><code class="attributevalue">negativethinmathspace</code></td>
-       <td>-3/18<code>em</code></td>
-      </tr>
-
-      <tr>
-       <td><code class="attributevalue">negativemediummathspace</code></td>
-       <td>-4/18<code>em</code></td>
-      </tr>
-
-      <tr>
-       <td><code class="attributevalue">negativethickmathspace</code></td>
-       <td>-5/18<code>em</code></td>
-      </tr>
-
-      <tr>
-       <td><code class="attributevalue">negativeverythickmathspace</code></td>
-       <td>-6/18<code>em</code></td>
-      </tr>
-
-      <tr>
-       <td><code class="attributevalue">negativeveryverythickmathspace</code></td>
-       <td>-7/18<code>em</code></td>
-      </tr>
-     </tbody>
-    </table>
+       <span style="white-space:nowrap"><code class="attributevalue">veryverythinmathspace</code> =
+       1/18&#x2009;em</span>,
+       <span style="white-space:nowrap"><code class="attributevalue">verythinmathspace</code> =
+       2/18&#x2009;em</span>,
+       <span style="white-space:nowrap"><code class="attributevalue">thinmathspace</code> =
+       3/18&#x2009;em</span>,
+       <span style="white-space:nowrap"><code class="attributevalue">mediummathspace</code> =
+       4/18&#x2009;em</span>,
+       <span style="white-space:nowrap"><code class="attributevalue">thickmathspace</code> =
+       5/18&#x2009;em</span>,
+       <span style="white-space:nowrap"><code class="attributevalue">verythickmathspace</code> =
+       6/18&#x2009;em</span>,
+       <span style="white-space:nowrap"><code class="attributevalue">veryverythickmathspace</code> =
+       7/18&#x2009;em</span>,
+       <span style="white-space:nowrap"><code class="attributevalue">negativeveryverythinmathspace</code> =
+       &#x2212;1/18&#x2009;em</span>,
+       <span style="white-space:nowrap"><code class="attributevalue">negativeverythinmathspace</code> =
+       &#x2212;2/18&#x2009;em</span>,
+       <span style="white-space:nowrap"><code class="attributevalue">negativethinmathspace</code> =
+       &#x2212;3/18&#x2009;em</span>,
+       <span style="white-space:nowrap"><code class="attributevalue">negativemediummathspace</code> =
+       &#x2212;4/18&#x2009;em</span>,
+       <span style="white-space:nowrap"><code class="attributevalue">negativethickmathspace</code> =
+       &#x2212;5/18&#x2009;em</span>,
+       <span style="white-space:nowrap"><code class="attributevalue">negativeverythickmathspace</code> =
+       &#x2212;6/18&#x2009;em</span>,
+       <span style="white-space:nowrap"><code class="attributevalue">negativeveryverythickmathspace</code> =
+       &#x2212;7/18&#x2009;em</span>.
     </p>
 
     <section>
      <h6 id="units_addl_notes">Additional notes about units</h6>
 
-
-     <p>Since these units track the display context, and in particular,
-     the user's preferences for display, the relative units <code>em</code> and <code>ex</code>
-     are generally to be preferred over absolute units such as <code>px</code> or <code>cm</code>.
-     </p>
 
      <p>Two additional aspects of relative units must be clarified, however.
      First, some elements such as <a href="#presm_scrlim"></a> or <code class="element">mfrac</code>,
@@ -519,8 +425,6 @@
      and <code class="attribute">scriptlevel</code>, must be processed before
      evaluating other length valued attributes.
      </p>
-
-     <p>If, and how, lengths might affect non-visual media is implementation specific.</p>
 
     </section>
    </section>


### PR DESCRIPTION
Following a similar path to color, this re-interprets mathml lengths as a modification from the css3 `length-percentage` (the only syntax allowed in core)

as it no longer "builds up" from definitions of digit and hexdigit these definitions are removed (which will leave some broken links from the presentation mathml syntax tables that will need fixing on a second sweep through).

added are named lengths, unitless lengths and mpadded `height`, `depth`, `width` pseudo-units.

Not added are magic interpretations of + and - signs in lengths (I think with core defering to css here we need to do the same 

That is, MathML3 said of mpadded width="+3em"

> If the value of a size attribute begins with a + or - sign, it specifies an increment or decrement to the corresponding dimension by the following length value.

But in mathml-core it is the same as width=3em and I think we have to follow core here.

This doesn't directly affect the PR which is only defining the syntax, +3em is legal in either case, but commenting here as this would be a technically breaking change.

We could consider adding new attributes eg change-width="3em" which would be a lot easier to understand than width="+3em" 

