### PR TITLE
change tables to use 'data'

### DIFF
--- a/index.html
+++ b/index.html
@@ -203,6 +203,8 @@ table.attributes td[colspan] {text-align: left !important}
 table.attributes td { padding-left:0.5em; padding-right:0.5em; border: solid thin; }
 table.attributes td.attname { white-space:nowrap; vertical-align:top; font-weight:bold;}
 table.attributes thead {font-weight:bold;}
+table.elements thead {font-weight:bold;}
+table.elements tr td:first-child {border-right: solid var(--datacell-border) thin;}
 div.example pre {margin-top:0;margin-bottom:0;}
 pre.nonumexample{
 border: .5em;

--- a/src/presentation-markup.html
+++ b/src/presentation-markup.html
@@ -196,7 +196,7 @@
     Although the <code class="element">math</code> element is
     not a presentation element, it is listed below for completeness.
 
-    <table id="presm_table-reqarg" border="1">
+    <table id="presm_table-reqarg" class="elements data">
 
      <thead>
 
@@ -711,7 +711,7 @@
   <section>
    <h5>Token Elements</h5>
 
-   <table border="1">
+   <table class="elements data">
 
     <tbody>
 
@@ -754,7 +754,7 @@
   <section>
    <h5>General Layout Schemata</h5>
 
-   <table border="1">
+   <table class="elements data">
 
     <tbody>
 
@@ -814,7 +814,7 @@
   <section>
    <h5>Script and Limit Schemata</h5>
 
-   <table border="1">
+   <table class="elements data">
 
     <tbody>
 
@@ -859,7 +859,7 @@
   <section>
    <h5>Tables and Matrices</h5>
 
-   <table border="1">
+   <table class="elements data">
 
     <tbody>
 
@@ -896,7 +896,7 @@
   <section>
    <h5>Elementary Math Layout</h5>
 
-   <table border="1">
+   <table class="elements data">
 
     <tbody>
 
@@ -941,7 +941,7 @@
   <section>
    <h5>Enlivening Expressions</h5>
 
-   <table border="1">
+   <table class="elements data">
 
     <tbody>
 
@@ -960,7 +960,7 @@
   <p>In addition to the attributes listed in <a href="#fund_globatt"></a>,
   all MathML presentation elements accept the following two attributes:
 
-  <table border="1" class="attributes">
+  <table class="attributes data">
 
    <thead>
 
@@ -1141,7 +1141,7 @@
     <p>
     <code class="element">mglyph</code> also accepts the additional attributes listed here.</p>
 
-    <table border="1" class="attributes">
+    <table class="attributes data">
 
      <thead>
 
@@ -1273,7 +1273,7 @@
     web fonts widely available, this use of <code class="element">mglyph</code> has been deprecated.
     For reference, the following attributes were previously defined:
 
-    <table border="1" class="attributes">
+    <table class="attributes data">
 
      <thead>
 
@@ -1340,7 +1340,7 @@
   <code class="attribute">dir</code> is also valid on <code class="element">mrow</code> elements.</span>
   The attributes are:
 
-  <table border="1" class="attributes">
+  <table class="attributes data">
 
    <thead>
 
@@ -1526,7 +1526,7 @@
 
    <p>The deprecated attributes are:
 
-   <table border="1" class="attributes">
+   <table class="attributes data">
 
     <thead>
 
@@ -1714,7 +1714,7 @@
    <p><code class="element">mi</code> elements accept the attributes listed in
    <a href="#presm_commatt"></a>, but in one case with a different default value:
 
-   <table border="1" class="attributes">
+   <table class="attributes data">
 
     <thead>
 
@@ -2065,7 +2065,7 @@
    <section>
     <h6 id="presm_mo_dict_attrs">Dictionary-based attributes</h6>
     <div class="issue" data-number="294"></div>
-    <table border="1" id="presm_table-mo" class="attributes">
+    <table id="presm_table-mo" class="attributes data">
 
      <thead>
 
@@ -2285,7 +2285,7 @@
     <p>The following attributes affect when a linebreak does or does not occur,
     and the appearance of the linebreak when it does occur.</p>
 
-    <table border="1" class="attributes">
+    <table class="attributes data">
 
      <thead>
 
@@ -2409,7 +2409,7 @@
     in a line in
     which the remaining width exceeds the available linewrapping width. </p>
 
-    <table border="1" class="attributes">
+    <table class="attributes data">
 
      <thead>
       <tr>
@@ -2718,7 +2718,7 @@
    by nothing. The characters used for these <span>&#x201c;invisible
    operators&#x201d;</span> are:
 
-   <table border="1">
+   <table class="data">
 
     <thead>
 
@@ -3614,7 +3614,7 @@ attributes (see <a href="#fund_units"></a>).
 
 </p>
 
-<table border="1" class="attributes">
+<table class="attributes data">
 
  <thead>
 
@@ -3868,7 +3868,7 @@ the content should be encoded as described in that section.</p>
 <p><code class="element">ms</code> elements accept the attributes listed in
 <a href="#presm_commatt"></a>, and additionally: </p>
 
-<table border="1" class="attributes">
+<table class="attributes data">
 
  <thead>
 
@@ -3977,7 +3977,7 @@ on other elements (See <a href="#presm_linebreaking"></a>).
  <p><code class="element">mrow</code> elements accept the attribute listed below in addition to
  those listed in <a href="#presm_presatt"></a>.</p>
 
- <table border="1" class="attributes">
+ <table class="attributes data">
 
   <thead>
 
@@ -4171,7 +4171,7 @@ within <em>numerator</em> and <em>denominator</em>.
 in addition to those listed in <a href="#presm_presatt"></a>.
 The fraction line, if any, should be drawn using the color specified by <code class="attribute">mathcolor</code>.</p>
 
-<table border="1" class="attributes">
+<table class="attributes data">
 
  <thead>
 
@@ -4544,7 +4544,7 @@ accepted by the <code class="element">mstyle</code> element.</p>
 attributes that are implicitly inherited by every MathML element as
 part of its rendering environment:
 
-<table border="1" class="attributes">
+<table class="attributes data">
 
  <thead>
 
@@ -4678,7 +4678,7 @@ For backwards compatibility, the following attributes are accepted
 on the <code class="element">mstyle</code> element, but are expected to have no effect.
 </p>
 
-<table border="1" class="attributes">
+<table class="attributes data">
 
  <thead>
 
@@ -4895,7 +4895,7 @@ section on &lt;mo&gt;,
   <p><code class="element">mpadded</code> elements accept the attributes listed
   below in addition to those specified in <a href="#presm_presatt"></a>.</p>
 
-  <table border="1" class="attributes">
+  <table class="attributes data">
 
    <thead>
 
@@ -5481,7 +5481,7 @@ section on &lt;mo&gt;,
   below in addition to those specified in <a href="#presm_presatt"></a>.
   The delimiters and separators should be drawn using the color specified by <code class="attribute">mathcolor</code>.</p>
 
-  <table border="1" class="attributes">
+  <table class="attributes data">
 
    <thead>
 
@@ -5768,7 +5768,7 @@ section on &lt;mo&gt;,
 
   <div class="issue" data-number="3"></div>
 
-  <table border="1" class="attributes">
+  <table class="attributes data">
 
    <thead>
 
@@ -6093,7 +6093,7 @@ section on &lt;mo&gt;,
    <p><code class="element">msub</code> elements accept the attributes listed
    below in addition to those specified in <a href="#presm_presatt"></a>.</p>
 
-   <table border="1" class="attributes">
+   <table class="attributes data">
 
     <thead>
 
@@ -6150,7 +6150,7 @@ section on &lt;mo&gt;,
    <p><code class="element">msup</code> elements accept the attributes listed
    below in addition to those specified in <a href="#presm_presatt"></a>.</p>
 
-   <table border="1" class="attributes">
+   <table class="attributes data">
 
     <thead>
 
@@ -6216,7 +6216,7 @@ section on &lt;mo&gt;,
    <p><code class="element">msubsup</code> elements accept the attributes listed
    below in addition to those specified in <a href="#presm_presatt"></a>.</p>
 
-   <table border="1" class="attributes">
+   <table class="attributes data">
 
     <thead>
 
@@ -6339,7 +6339,7 @@ section on &lt;mo&gt;,
    <p><code class="element">munder</code> elements accept the attributes listed
    below in addition to those specified in <a href="#presm_presatt"></a>.</p>
 
-   <table border="1" class="attributes">
+   <table class="attributes data">
 
     <thead>
 
@@ -6476,7 +6476,7 @@ section on &lt;mo&gt;,
 
    <p>
 
-    <table border="1" class="attributes">
+    <table class="attributes data">
 
      <thead>
 
@@ -6633,7 +6633,7 @@ section on &lt;mo&gt;,
    <p><code class="element">munderover</code> elements accept the attributes listed
    below in addition to those specified in <a href="#presm_presatt"></a>.</p>
 
-   <table border="1" class="attributes">
+   <table class="attributes data">
 
     <thead>
 
@@ -7003,7 +7003,7 @@ section on &lt;mo&gt;,
    Any rules drawn as part of the <code class="element">mtable</code> should be drawn using the color
    specified by <code class="attribute">mathcolor</code>.</p>
 
-   <table border="1" class="attributes">
+   <table class="attributes data">
 
     <thead>
 
@@ -7435,7 +7435,7 @@ section on &lt;mo&gt;,
    <p><code class="element">mtr</code> elements accept the attributes listed
    below in addition to those specified in <a href="#presm_presatt"></a>.</p>
 
-   <table border="1" class="attributes">
+   <table class="attributes data">
 
     <thead>
 
@@ -7667,7 +7667,7 @@ section on &lt;mo&gt;,
    <p><code class="element">mtd</code> elements accept the attributes listed
    below in addition to those specified in <a href="#presm_presatt"></a>.</p>
 
-   <table border="1" class="attributes">
+   <table class="attributes data">
 
     <thead>
 
@@ -8096,7 +8096,7 @@ section on &lt;mo&gt;,
    below in addition to those specified in <a href="#presm_presatt"></a>
    (however, neither <code class="attribute">mathcolor</code> nor <code class="attribute">mathbackground</code> have any effect).</p>
 
-   <table border="1" class="attributes">
+   <table class="attributes data">
 
     <thead>
 
@@ -8178,7 +8178,7 @@ section on &lt;mo&gt;,
    below in addition to those specified in <a href="#presm_presatt"></a>
    (however, neither <code class="attribute">mathcolor</code> nor <code class="attribute">mathbackground</code> have any effect).</p>
 
-   <table border="1" class="attributes">
+   <table class="attributes data">
 
     <thead>
 
@@ -8336,7 +8336,7 @@ value.</p>
 elements that have this attribute are specified using the above
 syntax definitions as follows:
 
-<table border="1">
+<table class="data">
 
  <thead>
 
@@ -8840,7 +8840,7 @@ Any rules drawn as part of division layout should be drawn using the color speci
 by
 <code class="attribute">mathcolor</code>.</p>
 
-<table border="1" class="attributes">
+<table class="attributes data">
 
  <thead>
 
@@ -8955,7 +8955,7 @@ are treated as if they are implicitly surrounded by an <code class="element">msg
 <p><code class="element">msgroup</code> elements accept the attributes listed
 below in addition to those specified in <a href="#presm_presatt"></a>.</p>
 
-<table border="1" class="attributes">
+<table class="attributes data">
 
  <thead>
 
@@ -9052,7 +9052,7 @@ see <a href="#presm_bidi"></a>.
 <p><code class="element">msrow</code> elements accept the attributes listed
 below in addition to those specified in <a href="#presm_presatt"></a>.</p>
 
-<table border="1" class="attributes">
+<table class="attributes data">
 
  <thead>
 
@@ -9141,7 +9141,7 @@ see <a href="#presm_bidi"></a>.
 <p><code class="element">mscarries</code> elements accept the attributes listed
 below in addition to those specified in <a href="#presm_presatt"></a>.</p>
 
-<table border="1" class="attributes">
+<table class="attributes data">
 
  <thead>
 
@@ -9255,7 +9255,7 @@ due to the enclosing <code class="element">mscarries</code> to be drawn for the 
 <p>The <code class="element">mscarry</code> element accepts the attributes listed
 below in addition to those specified in <a href="#presm_presatt"></a>.</p>
 
-<table border="1" class="attributes">
+<table class="attributes data">
 
  <thead>
 
@@ -9325,7 +9325,7 @@ below in addition to those specified in <a href="#presm_presatt"></a>.
 The line should be drawn using the color specified by <code class="attribute">mathcolor</code>.
 </p>
 
-<table border="1" class="attributes">
+<table class="attributes data">
 
  <thead>
 
@@ -9945,7 +9945,7 @@ defined below. If no selected sub-expression exists, it is a MathML
 error; the appropriate rendering in that case is as described in
 <a href="#interf_error"></a>.</p>
 
-<table border="1" class="attributes">
+<table class="attributes data">
 
  <thead>
 


### PR DESCRIPTION
I added the 'data' attr to the tables.

I like the look of the attr tables. I'm not keen on the look for the tables of elements. I added a `elements` class to them in the hopes that @davidcarlisle can add some CSS magic to improve their looks (currently they have `class="elements data"`