### PR TITLE
Davidc/mfenced

### DIFF
--- a/src/contm-new.html
+++ b/src/contm-new.html
@@ -802,7 +802,7 @@
            &lt;mrow&gt;
              &lt;mi&gt;Polar&lt;/mi&gt;
              &lt;mo&gt;&amp;#x2061;&lt;/mo&gt;
-             &lt;mfenced&gt;&lt;mn&gt;2&lt;/mn&gt;&lt;mn&gt;3.1415&lt;/mn&gt;&lt;/mfenced&gt;
+             &lt;mrow&gt;&lt;mn&gt;2&lt;/mn&gt;&lt;mo&gt;,&lt;/mo&gt;&lt;mn&gt;3.1415&lt;/mn&gt;&lt;/mrow&gt;
            &lt;/mrow&gt;
 	 </pre>
         </div>
@@ -3603,7 +3603,7 @@
            &lt;mrow&gt;
              &lt;mrow&gt;&lt;mo&gt;(&lt;/mo&gt;&lt;mi&gt;f&lt;/mi&gt;&lt;mo&gt;&amp;#x2218;&lt;/mo&gt;&lt;mi&gt;g&lt;/mi&gt;&lt;mo&gt;)&lt;/mo&gt;&lt;/mrow&gt;
              &lt;mo&gt;&amp;#x2061;&lt;/mo&gt;
-             &lt;mfenced&gt;&lt;mi&gt;x&lt;/mi&gt;&lt;/mfenced&gt;
+             &lt;mrow&gt;&lt;mo&gt;(&lt;/mo&gt;&lt;mi&gt;x&lt;/mi&gt;&lt;mo&gt;)&lt;/mo&gt;&lt;/mrow&gt;
            &lt;/mrow&gt;
            &lt;mo&gt;=&lt;/mo&gt;
            &lt;mrow&gt;
@@ -3613,7 +3613,7 @@
                &lt;mrow&gt;
                  &lt;mi&gt;g&lt;/mi&gt;
                  &lt;mo&gt;&amp;#x2061;&lt;/mo&gt;
-                 &lt;mfenced&gt;&lt;mi&gt;x&lt;/mi&gt;&lt;/mfenced&gt;
+                 &lt;mrow&gt;&lt;mo&gt;(&lt;/mo&gt;&lt;mi&gt;x&lt;/mi&gt;&lt;mo&gt;)&lt;/mo&gt;&lt;/mrow&gt;
                &lt;/mrow&gt;
              &lt;/mfenced&gt;
            &lt;/mrow&gt;
@@ -5520,7 +5520,7 @@
            &lt;mo&gt;.&lt;/mo&gt;
            &lt;mfenced&gt;
              &lt;mrow&gt;
-               &lt;mrow&gt;&lt;mi&gt;f&lt;/mi&gt;&lt;mo&gt;&amp;#x2061;&lt;/mo&gt;&lt;mfenced&gt;&lt;mi&gt;x&lt;/mi&gt;&lt;/mfenced&gt;&lt;/mrow&gt;
+               &lt;mrow&gt;&lt;mi&gt;f&lt;/mi&gt;&lt;mo&gt;&amp;#x2061;&lt;/mo&gt;&lt;mrow&gt;&lt;mo&gt;(&lt;/mo&gt;&lt;mi&gt;x&lt;/mi&gt;&lt;mo&gt;)&lt;/mo&gt;&lt;/mrow&gt;&lt;/mrow&gt;
                &lt;mo&gt;=&lt;/mo&gt;
                &lt;mn&gt;0&lt;/mn&gt;
              &lt;/mrow&gt;
@@ -5585,7 +5585,7 @@
              &lt;mrow&gt;&lt;mi&gt;x&lt;/mi&gt;&lt;mo&gt;&amp;#x2208;&lt;/mo&gt;&lt;mi mathvariant="double-struck"&gt;Z&lt;/mi&gt;&lt;/mrow&gt;
              &lt;mo&gt;&amp;#x2227;&lt;/mo&gt;
              &lt;mrow&gt;
-               &lt;mrow&gt;&lt;mi&gt;f&lt;/mi&gt;&lt;mo&gt;&amp;#x2061;&lt;/mo&gt;&lt;mfenced&gt;&lt;mi&gt;x&lt;/mi&gt;&lt;/mfenced&gt;&lt;/mrow&gt;
+               &lt;mrow&gt;&lt;mi&gt;f&lt;/mi&gt;&lt;mo&gt;&amp;#x2061;&lt;/mo&gt;&lt;mrow&gt;&lt;mo&gt;(&lt;/mo&gt;&lt;mi&gt;x&lt;/mi&gt;&lt;mo&gt;)&lt;/mo&gt;&lt;/mrow&gt;&lt;/mrow&gt;
                &lt;mo&gt;=&lt;/mo&gt;
                &lt;mn&gt;0&lt;/mn&gt;
              &lt;/mrow&gt;
@@ -8773,7 +8773,7 @@
              &lt;mrow&gt;&lt;mi&gt;x&lt;/mi&gt;&lt;mo&gt;=&lt;/mo&gt;&lt;mi&gt;a&lt;/mi&gt;&lt;/mrow&gt;
              &lt;mi&gt;b&lt;/mi&gt;
            &lt;/munderover&gt;
-           &lt;mrow&gt;&lt;mi&gt;f&lt;/mi&gt;&lt;mo&gt;&amp;#x2061;&lt;/mo&gt;&lt;mfenced&gt;&lt;mi&gt;x&lt;/mi&gt;&lt;/mfenced&gt;&lt;/mrow&gt;
+           &lt;mrow&gt;&lt;mi&gt;f&lt;/mi&gt;&lt;mo&gt;&amp;#x2061;&lt;/mo&gt;&lt;mrow&gt;&lt;mo&gt;(&lt;/mo&gt;&lt;mi&gt;x&lt;/mi&gt;&lt;mo&gt;)&lt;/mo&gt;&lt;/mrow&gt;&lt;/mrow&gt;
          &lt;/mrow&gt;
        </pre>
       </div>
@@ -8808,7 +8808,7 @@
              &lt;mo&gt;&amp;#x2211;&lt;/mo&gt;
              &lt;mrow&gt;&lt;mi&gt;x&lt;/mi&gt;&lt;mo&gt;&amp;#x2208;&lt;/mo&gt;&lt;mi&gt;B&lt;/mi&gt;&lt;/mrow&gt;
            &lt;/munder&gt;
-           &lt;mrow&gt;&lt;mi&gt;f&lt;/mi&gt;&lt;mo&gt;&amp;#x2061;&lt;/mo&gt;&lt;mfenced&gt;&lt;mi&gt;x&lt;/mi&gt;&lt;/mfenced&gt;&lt;/mrow&gt;
+           &lt;mrow&gt;&lt;mi&gt;f&lt;/mi&gt;&lt;mo&gt;&amp;#x2061;&lt;/mo&gt;&lt;mrow&gt;&lt;mo&gt;(&lt;/mo&gt;&lt;mi&gt;x&lt;/mi&gt;&lt;mo&gt;)&lt;/mo&gt;&lt;/mrow&gt;&lt;/mrow&gt;
          &lt;/mrow&gt;
        </pre>
       </div>
@@ -8930,7 +8930,7 @@
              &lt;mrow&gt;&lt;mi&gt;x&lt;/mi&gt;&lt;mo&gt;=&lt;/mo&gt;&lt;mi&gt;a&lt;/mi&gt;&lt;/mrow&gt;
              &lt;mi&gt;b&lt;/mi&gt;
            &lt;/munderover&gt;
-           &lt;mrow&gt;&lt;mi&gt;f&lt;/mi&gt;&lt;mo&gt;&amp;#x2061;&lt;/mo&gt;&lt;mfenced&gt;&lt;mi&gt;x&lt;/mi&gt;&lt;/mfenced&gt;&lt;/mrow&gt;
+           &lt;mrow&gt;&lt;mi&gt;f&lt;/mi&gt;&lt;mo&gt;&amp;#x2061;&lt;/mo&gt;&lt;mrow&gt;&lt;mo&gt;(&lt;/mo&gt;&lt;mi&gt;x&lt;/mi&gt;&lt;mo&gt;)&lt;/mo&gt;&lt;/mrow&gt;&lt;/mrow&gt;
          &lt;/mrow&gt;
        </pre>
       </div>
@@ -8968,7 +8968,7 @@
              &lt;mo&gt;&amp;#x220f;&lt;/mo&gt;
              &lt;mrow&gt;&lt;mi&gt;x&lt;/mi&gt;&lt;mo&gt;&amp;#x2208;&lt;/mo&gt;&lt;mi&gt;B&lt;/mi&gt;&lt;/mrow&gt;
            &lt;/munder&gt;
-           &lt;mrow&gt;&lt;mi&gt;f&lt;/mi&gt;&lt;mo&gt;&amp;#x2061;&lt;/mo&gt;&lt;mfenced&gt;&lt;mi&gt;x&lt;/mi&gt;&lt;/mfenced&gt;&lt;/mrow&gt;
+           &lt;mrow&gt;&lt;mi&gt;f&lt;/mi&gt;&lt;mo&gt;&amp;#x2061;&lt;/mo&gt;&lt;mrow&gt;&lt;mo&gt;(&lt;/mo&gt;&lt;mi&gt;x&lt;/mi&gt;&lt;mo&gt;)&lt;/mo&gt;&lt;/mrow&gt;&lt;/mrow&gt;
          &lt;/mrow&gt;
        </pre>
       </div>
@@ -9960,7 +9960,7 @@
        <pre>
          &lt;mrow&gt;
            &lt;mo&gt;&amp;#x3c3;&lt;/mo&gt;
-           &lt;mo&gt;&amp;#x2061;&lt;/mo&gt;&lt;mfenced&gt;&lt;mi&gt;X&lt;/mi&gt;&lt;/mfenced&gt;
+           &lt;mo&gt;&amp;#x2061;&lt;/mo&gt;&lt;mrow&gt;&lt;mo&gt;(&lt;/mo&gt;&lt;mi&gt;x&lt;/mi&gt;&lt;mo&gt;)&lt;/mo&gt;&lt;/mrow&gt;
          &lt;/mrow&gt;
        </pre>
       </div>
@@ -10060,7 +10060,7 @@
          &lt;mrow&gt;
            &lt;msup&gt;&lt;mo&gt;&amp;#x3c3;&lt;/mo&gt;&lt;mn&gt;2&lt;/mn&gt;&lt;/msup&gt;
            &lt;mo&gt;&amp;#x2061;&lt;/mo&gt;
-           &lt;mfenced&gt;&lt;mi&gt;X&lt;/mi&gt;&lt;/mfenced&gt;
+           &lt;mrow&gt;&lt;mo&gt;(&lt;/mo&gt;&lt;mi&gt;x&lt;/mi&gt;&lt;mo&gt;)&lt;/mo&gt;&lt;/mrow&gt;
          &lt;/mrow&gt;
        </pre>
       </div>

--- a/src/contm-new.html
+++ b/src/contm-new.html
@@ -5589,7 +5589,8 @@
            &lt;mo&gt;&amp;#x2203;&lt;/mo&gt;
            &lt;mi&gt;x&lt;/mi&gt;
            &lt;mo&gt;.&lt;/mo&gt;
-           &lt;mfenced separators=""&gt;
+           &lt;mrow&gt;
+	    &lt;mo&gt;(&lt;/mo&gt;
              &lt;mrow&gt;&lt;mi&gt;x&lt;/mi&gt;&lt;mo&gt;&amp;#x2208;&lt;/mo&gt;&lt;mi mathvariant="double-struck"&gt;Z&lt;/mi&gt;&lt;/mrow&gt;
              &lt;mo&gt;&amp;#x2227;&lt;/mo&gt;
              &lt;mrow&gt;
@@ -5597,7 +5598,8 @@
                &lt;mo&gt;=&lt;/mo&gt;
                &lt;mn&gt;0&lt;/mn&gt;
              &lt;/mrow&gt;
-           &lt;/mfenced&gt;
+	     &lt;mo&gt;)&lt;/mo&gt;
+	   &lt;/mrow&gt;
          &lt;/mrow&gt;
        </pre>
       </div>
@@ -5868,13 +5870,15 @@
          &lt;mrow&gt;
            &lt;mo&gt;&amp;#x211b;&lt;/mo&gt;
            &lt;mo&gt;&amp;#x2061;&lt;/mo&gt;
-           &lt;mfenced&gt;
+           &lt;mrow&gt;
+	    &lt;mo&gt;(&lt;/mo&gt;
              &lt;mrow&gt;
                &lt;mi&gt;x&lt;/mi&gt;
                &lt;mo&gt;+&lt;/mo&gt;
                &lt;mrow&gt;&lt;mi&gt;i&lt;/mi&gt;&lt;mo&gt;&amp;#x2062;&lt;/mo&gt;&lt;mi&gt;y&lt;/mi&gt;&lt;/mrow&gt;
              &lt;/mrow&gt;
-           &lt;/mfenced&gt;
+	     &lt;mo&gt;)&lt;/mo&gt;
+	   &lt;/mrow&gt;
          &lt;/mrow&gt;
        </pre>
       </div>
@@ -5941,13 +5945,15 @@
          &lt;mrow&gt;
            &lt;mo&gt;&amp;#x2111;&lt;/mo&gt;
            &lt;mo&gt;&amp;#x2061;&lt;/mo&gt;
-           &lt;mfenced&gt;
+           &lt;mrow&gt;
+	    &lt;mo&gt;(&lt;/mo&gt;
              &lt;mrow&gt;
                &lt;mi&gt;x&lt;/mi&gt;
                &lt;mo&gt;+&lt;/mo&gt;
                &lt;mrow&gt;&lt;mi&gt;i&lt;/mi&gt;&lt;mo&gt;&amp;#x2062;&lt;/mo&gt;&lt;mi&gt;y&lt;/mi&gt;&lt;/mrow&gt;
              &lt;/mrow&gt;
-           &lt;/mfenced&gt;
+	     &lt;mo&gt;)&lt;/mo&gt;
+	   &lt;/mrow&gt;
          &lt;/mrow&gt;
        </pre>
       </div>
@@ -7097,7 +7103,7 @@
            &lt;mrow&gt;
              &lt;msup&gt;&lt;mo&gt;&amp;#x2202;&lt;/mo&gt;&lt;mn&gt;3&lt;/mn&gt;&lt;/msup&gt;
              &lt;mrow&gt;
-               &lt;mi&gt;f&lt;/mi&gt;&lt;mo&gt;&amp;#x2061;&lt;/mo&gt;&lt;mfenced&gt;&lt;mi&gt;x&lt;/mi&gt;&lt;mi&gt;y&lt;/mi&gt;&lt;mi&gt;z&lt;/mi&gt;&lt;/mfenced&gt;
+               &lt;mi&gt;f&lt;/mi&gt;&lt;mo&gt;&amp;#x2061;&lt;/mo&gt;&lt;mrow&gt;&lt;mo&gt;(&lt;/mo&gt;&lt;mi&gt;x&lt;/mi&gt;&lt;mo&gt;,&lt;/mo&gt;&lt;mi&gt;y&lt;/mi&gt;&lt;mo&gt;,&lt;/mo&gt;&lt;mi&gt;z&lt;/mi&gt;&lt;mo&gt;)&lt;/mo&gt;&lt;/mrow&gt;
              &lt;/mrow&gt;
            &lt;/mrow&gt;
            &lt;mrow&gt;
@@ -7188,7 +7194,7 @@
            &lt;mrow&gt;
              &lt;msup&gt;&lt;mo&gt;&amp;#x2202;&lt;/mo&gt;&lt;mi&gt;k&lt;/mi&gt;&lt;/msup&gt;
              &lt;mrow&gt;
-               &lt;mi&gt;f&lt;/mi&gt;&lt;mo&gt;&amp;#x2061;&lt;/mo&gt;&lt;mfenced&gt;&lt;mi&gt;x&lt;/mi&gt;&lt;mi&gt;y&lt;/mi&gt;&lt;/mfenced&gt;
+               &lt;mi&gt;f&lt;/mi&gt;&lt;mo&gt;&amp;#x2061;&lt;/mo&gt;&lt;mrow&gt;&lt;mo&gt;(&lt;/mo&gt;&lt;mi&gt;x&lt;/mi&gt;&lt;mo&gt;,&lt;/mo&gt;&lt;mi&gt;y&lt;/mi&gt;&lt;mo&gt;)&lt;/mo&gt;&lt;/mrow&gt;
              &lt;/mrow&gt;
            &lt;/mrow&gt;
            &lt;mrow&gt;
@@ -7254,7 +7260,7 @@
 
       <div class="example mathml">
        <pre>
-         &lt;mrow&gt;&lt;mi&gt;div&lt;/mi&gt;&lt;mo&gt;&amp;#x2061;&lt;/mo&gt;&lt;mfenced&gt;&lt;mi&gt;a&lt;/mi&gt;&lt;/mfenced&gt;&lt;/mrow&gt;
+         &lt;mrow&gt;&lt;mi&gt;div&lt;/mi&gt;&lt;mo&gt;&amp;#x2061;&lt;/mo&gt;&lt;mrow&gt;&lt;mo&gt;(&lt;/mo&gt;&lt;mi&gt;a&lt;/mi&gt;&lt;mo&gt;)&lt;/mo&gt;&lt;/mrow&gt;&lt;/mrow&gt;
        </pre>
       </div>
 
@@ -7278,7 +7284,7 @@
 
       <div class="example mathml">
        <pre>
-         &lt;mrow&gt;&lt;mi&gt;div&lt;/mi&gt;&lt;mo&gt;&amp;#x2061;&lt;/mo&gt;&lt;mfenced&gt;&lt;mi&gt;E&lt;/mi&gt;&lt;/mfenced&gt;&lt;/mrow&gt;
+         &lt;mrow&gt;&lt;mi&gt;div&lt;/mi&gt;&lt;mo&gt;&amp;#x2061;&lt;/mo&gt;&lt;mrow&gt;&lt;mo&gt;(&lt;/mo&gt;&lt;mi&gt;E&lt;/mi&gt;&lt;mo&gt;)&lt;/mo&gt;&lt;/mrow&gt;&lt;/mrow&gt;
        </pre>
       </div>
 
@@ -9240,19 +9246,19 @@
 
       <div class="example mathml">
        <pre>
-         &lt;mfenced&gt;&lt;mtable&gt;
+         &lt;mrow&gt;&lt;mo&gt;(&lt;/mo&gt;&lt;mtable&gt;
            &lt;mtr&gt;&lt;mtd&gt;&lt;mi&gt;x&lt;/mi&gt;&lt;/mtd&gt;&lt;/mtr&gt;
            &lt;mtr&gt;&lt;mtd&gt;&lt;mi&gt;y&lt;/mi&gt;&lt;/mtd&gt;&lt;/mtr&gt;
-         &lt;/mtable&gt;&lt;/mfenced&gt;
+         &lt;/mtable&gt;&lt;mo&gt;)&lt;/mo&gt;&lt;/mrow&gt;
          &lt;mo&gt;&amp;#x2192;&lt;/mo&gt;
-         &lt;mfenced&gt;&lt;mtable&gt;
+         &lt;mrow&gt;&lt;mo&gt;(&lt;/mo&gt;&lt;mtable&gt;
            &lt;mtr&gt;&lt;mtd&gt;
-             &lt;mi&gt;f&lt;/mi&gt;&lt;mo&gt;&amp;#x2061;&lt;/mo&gt;&lt;mfenced&gt;&lt;mi&gt;x&lt;/mi&gt;&lt;mi&gt;y&lt;/mi&gt;&lt;/mfenced&gt;
+             &lt;mi&gt;f&lt;/mi&gt;&lt;mo&gt;&amp;#x2061;&lt;/mo&gt;&lt;mrow&gt;&lt;mo&gt;(&lt;/mo&gt;&lt;mi&gt;x&lt;/mi&gt;&lt;mo&gt;,&lt;/mo&gt;&lt;mi&gt;y&lt;/mi&gt;&lt;mo&gt;)&lt;/mo&gt;&lt;/mrow&gt;
            &lt;/mtd&gt;&lt;/mtr&gt;
            &lt;mtr&gt;&lt;mtd&gt;
-             &lt;mi&gt;g&lt;/mi&gt;&lt;mo&gt;&amp;#x2061;&lt;/mo&gt;&lt;mfenced&gt;&lt;mi&gt;x&lt;/mi&gt;&lt;mi&gt;y&lt;/mi&gt;&lt;/mfenced&gt;
+             &lt;mi&gt;g&lt;/mi&gt;&lt;mo&gt;&amp;#x2061;&lt;/mo&gt;&lt;mrow&gt;&lt;mo&gt;(&lt;/mo&gt;&lt;mi&gt;x&lt;/mi&gt;&lt;mo&gt;,&lt;/mo&gt;&lt;mi&gt;y&lt;/mi&gt;&lt;mo&gt;)&lt;/mo&gt;&lt;/mrow&gt;
            &lt;/mtd&gt;&lt;/mtr&gt;
-         &lt;/mtable&gt;&lt;/mfenced&gt;
+         &lt;/mtable&gt;&lt;mo&gt;)&lt;/mo&gt;&lt;/mrow&gt;
        </pre>
       </div>
 
@@ -10205,7 +10211,7 @@
          &lt;mrow&gt;
            &lt;mi&gt;mode&lt;/mi&gt;
            &lt;mo&gt;&amp;#x2061;&lt;/mo&gt;
-           &lt;mfenced&gt;&lt;mn&gt;3&lt;/mn&gt;&lt;mn&gt;4&lt;/mn&gt;&lt;mn&gt;2&lt;/mn&gt;&lt;mn&gt;2&lt;/mn&gt;&lt;/mfenced&gt;
+           &lt;mrow&gt;&lt;mo&gt;(&lt;/mo&gt;&lt;mn&gt;3&lt;/mn&gt;&lt;mo&gt;,&lt;/mo&gt;&lt;mn&gt;4&lt;/mn&gt;&lt;mo&gt;,&lt;/mo&gt;&lt;mn&gt;2&lt;/mn&gt;&lt;mo&gt;,&lt;/mo&gt;&lt;mn&gt;2&lt;/mn&gt;&lt;mo&gt;)&lt;/mo&gt;&lt;/mrow&gt;
          &lt;/mrow&gt;
        </pre>
       </div>
@@ -10283,7 +10289,7 @@
            &lt;mrow&gt;
              &lt;mo&gt;&amp;#x27E8;&lt;/mo&gt;
              &lt;msup&gt;
-               &lt;mfenced&gt;&lt;mn&gt;6&lt;/mn&gt;&lt;mn&gt;4&lt;/mn&gt;&lt;mn&gt;2&lt;/mn&gt;&lt;mn&gt;2&lt;/mn&gt;&lt;mn&gt;5&lt;/mn&gt;&lt;/mfenced&gt;
+               &lt;mrow&gt;&lt;mo&gt;(&lt;/mo&gt;&lt;mn&gt;6&lt;/mn&gt;&lt;mo&gt;,&lt;/mo&gt;&lt;mn&gt;4&lt;/mn&gt;&lt;mo&gt;,&lt;/mo&gt;&lt;mn&gt;2&lt;/mn&gt;&lt;mo&gt;,&lt;/mo&gt;&lt;mn&gt;2&lt;/mn&gt;&lt;mo&gt;,&lt;/mo&gt;&lt;mn&gt;5&lt;/mn&gt;&lt;mo&gt;)&lt;/mo&gt;&lt;/mrow&gt;
                &lt;mn&gt;3&lt;/mn&gt;
              &lt;/msup&gt;
              &lt;mo&gt;&amp;#x27E9;&lt;/mo&gt;
@@ -10420,11 +10426,15 @@
 
       <div class="example mathml">
        <pre>
-         &lt;mfenced&gt;
+         &lt;mrow&gt;
+           &lt;mo&gt;(&lt;/mo&gt;
            &lt;mrow&gt;&lt;mi&gt;x&lt;/mi&gt;&lt;mo&gt;+&lt;/mo&gt;&lt;mi&gt;y&lt;/mi&gt;&lt;/mrow&gt;
+	   &lt;mo&gt;,&lt;/mo&gt;
            &lt;mn&gt;3&lt;/mn&gt;
+	   &lt;mo&gt;,&lt;/mo&gt;
            &lt;mn&gt;7&lt;/mn&gt;
-         &lt;/mfenced&gt;
+           &lt;mo&gt;)&lt;/mo&gt;
+         &lt;/mrow&gt;
        </pre>
       </div>
 

--- a/src/contm-new.html
+++ b/src/contm-new.html
@@ -3237,7 +3237,7 @@
 
       <div class="example mathml">
        <pre>
-         &lt;mfenced&gt;&lt;mi&gt;x&lt;/mi&gt;&lt;mn&gt;1&lt;/mn&gt;&lt;/mfenced&gt;
+         &lt;mrow&gt;&lt;mo&gt;(&lt;/mo&gt;&lt;mi&gt;x&lt;/mi&gt;&lt;mo&gt;,&lt;/mo&gt;&lt;mn&gt;1&lt;/mn&gt;&lt;mo&gt;)&lt;/mo&gt;&lt;/mrow&gt;
        </pre>
       </div>
 
@@ -3247,7 +3247,7 @@
 
       <div class="example mathml">
        <pre>
-         &lt;mfenced open="[" close="]"&gt;&lt;mn&gt;0&lt;/mn&gt;&lt;mn&gt;1&lt;/mn&gt;&lt;/mfenced&gt;
+         &lt;mrow&gt;&lt;mo&gt;[&lt;/mo&gt;&lt;mn&gt;0&lt;/mn&gt;&lt;mo&gt;,&lt;/mo&gt;&lt;mn&gt;1&lt;/mn&gt;&lt;mo&gt;]&lt;/mo&gt;&lt;/mrow&gt;
        </pre>
       </div>
 
@@ -3257,7 +3257,7 @@
 
       <div class="example mathml">
        <pre>
-         &lt;mfenced open="(" close="]"&gt;&lt;mn&gt;0&lt;/mn&gt;&lt;mn&gt;1&lt;/mn&gt;&lt;/mfenced&gt;
+         &lt;mrow&gt;&lt;mo&gt;(&lt;/mo&gt;&lt;mn&gt;0&lt;/mn&gt;&lt;mo&gt;,&lt;/mo&gt;&lt;mn&gt;1&lt;/mn&gt;&lt;mo&gt;]&lt;/mo&gt;&lt;/mrow&gt;
        </pre>
       </div>
 
@@ -3267,7 +3267,7 @@
 
       <div class="example mathml">
        <pre>
-         &lt;mfenced open="[" close=")"&gt;&lt;mn&gt;0&lt;/mn&gt;&lt;mn&gt;1&lt;/mn&gt;&lt;/mfenced&gt;
+         &lt;mrow&gt;&lt;mo&gt;[&lt;/mo&gt;&lt;mn&gt;0&lt;/mn&gt;&lt;mo&gt;,&lt;/mo&gt;&lt;mn&gt;1&lt;/mn&gt;&lt;mo&gt;)&lt;/mo&gt;&lt;/mrow&gt;
        </pre>
       </div>
 
@@ -3357,7 +3357,7 @@
          &lt;mrow&gt;
            &lt;msup&gt;&lt;mi&gt;A&lt;/mi&gt;&lt;mrow&gt;&lt;mo&gt;(&lt;/mo&gt;&lt;mn&gt;-1&lt;/mn&gt;&lt;mo&gt;)&lt;/mo&gt;&lt;/mrow&gt;&lt;/msup&gt;
            &lt;mo&gt;&amp;#x2061;&lt;/mo&gt;
-           &lt;mfenced&gt;&lt;mi&gt;a&lt;/mi&gt;&lt;/mfenced&gt;
+           &lt;mrow&gt;&lt;mo&gt;(&lt;/mo&gt;&lt;mi&gt;a&lt;/mi&gt;&lt;mo&gt;)&lt;/mo&gt;&lt;/mrow&gt;
          &lt;/mrow&gt;
        </pre>
       </div>
@@ -3474,13 +3474,15 @@
            &lt;mi&gt;&amp;#x3bb;&lt;/mi&gt;
            &lt;mi&gt;x&lt;/mi&gt;
            &lt;mo&gt;.&lt;/mo&gt;
-           &lt;mfenced&gt;
+           &lt;mrow&gt;
+	    &lt;mo&gt;(&lt;/mo&gt;
              &lt;mrow&gt;
                &lt;mi&gt;sin&lt;/mi&gt;
                &lt;mo&gt;&amp;#x2061;&lt;/mo&gt;
                &lt;mrow&gt;&lt;mo&gt;(&lt;/mo&gt;&lt;mi&gt;x&lt;/mi&gt;&lt;mo&gt;+&lt;/mo&gt;&lt;mn&gt;1&lt;/mn&gt;&lt;mo&gt;)&lt;/mo&gt;&lt;/mrow&gt;
              &lt;/mrow&gt;
-           &lt;/mfenced&gt;
+	     &lt;mo&gt;)&lt;/mo&gt;
+           &lt;/mrow&gt;
          &lt;/mrow&gt;
        </pre>
       </div>
@@ -3609,13 +3611,15 @@
            &lt;mrow&gt;
              &lt;mi&gt;f&lt;/mi&gt;
              &lt;mo&gt;&amp;#x2061;&lt;/mo&gt;
-             &lt;mfenced&gt;
+             &lt;mrow&gt;
+	      &lt;mo&gt;(&lt;/mo&gt;
                &lt;mrow&gt;
                  &lt;mi&gt;g&lt;/mi&gt;
                  &lt;mo&gt;&amp;#x2061;&lt;/mo&gt;
                  &lt;mrow&gt;&lt;mo&gt;(&lt;/mo&gt;&lt;mi&gt;x&lt;/mi&gt;&lt;mo&gt;)&lt;/mo&gt;&lt;/mrow&gt;
                &lt;/mrow&gt;
-             &lt;/mfenced&gt;
+	       &lt;mo&gt;)&lt;/mo&gt;
+             &lt;/mrow&gt;
            &lt;/mrow&gt;
          &lt;/mrow&gt;
        </pre>
@@ -3751,7 +3755,7 @@
       <div class="example mathml">
        <pre>
          &lt;mrow&gt;
-           &lt;mrow&gt;&lt;mi&gt;domain&lt;/mi&gt;&lt;mo&gt;&amp;#x2061;&lt;/mo&gt;&lt;mfenced&gt;&lt;mi&gt;f&lt;/mi&gt;&lt;/mfenced&gt;&lt;/mrow&gt;
+           &lt;mrow&gt;&lt;mi&gt;domain&lt;/mi&gt;&lt;mo&gt;&amp;#x2061;&lt;/mo&gt;&lt;mrow&gt;&lt;mo&gt;(&lt;/mo&gt;&lt;mi&gt;f&lt;/mi&gt;&lt;mo&gt;)&lt;/mo&gt;&lt;/mrow&gt;&lt;/mrow&gt;
            &lt;mo&gt;=&lt;/mo&gt;
            &lt;mi mathvariant="double-struck"&gt;R&lt;/mi&gt;
          &lt;/mrow&gt;
@@ -3816,7 +3820,7 @@
       <div class="example mathml">
        <pre>
          &lt;mrow&gt;
-           &lt;mrow&gt;&lt;mi&gt;codomain&lt;/mi&gt;&lt;mo&gt;&amp;#x2061;&lt;/mo&gt;&lt;mfenced&gt;&lt;mi&gt;f&lt;/mi&gt;&lt;/mfenced&gt;&lt;/mrow&gt;
+           &lt;mrow&gt;&lt;mi&gt;codomain&lt;/mi&gt;&lt;mo&gt;&amp;#x2061;&lt;/mo&gt;&lt;mrow&gt;&lt;mo&gt;(&lt;/mo&gt;&lt;mi&gt;f&lt;/mi&gt;&lt;mo&gt;)&lt;/mo&gt;&lt;/mrow&gt;&lt;/mrow&gt;
            &lt;mo&gt;=&lt;/mo&gt;
            &lt;mi mathvariant="double-struck"&gt;Q&lt;/mi&gt;
          &lt;/mrow&gt;
@@ -3880,9 +3884,9 @@
       <div class="example mathml">
        <pre>
          &lt;mrow&gt;
-           &lt;mrow&gt;&lt;mi&gt;image&lt;/mi&gt;&lt;mo&gt;&amp;#x2061;&lt;/mo&gt;&lt;mfenced&gt;&lt;mi&gt;sin&lt;/mi&gt;&lt;/mfenced&gt;&lt;/mrow&gt;
+           &lt;mrow&gt;&lt;mi&gt;image&lt;/mi&gt;&lt;mo&gt;&amp;#x2061;&lt;/mo&gt;&lt;mrow&gt;&lt;mo&gt;(&lt;/mo&gt;&lt;mi&gt;sin&lt;/mi&gt;&lt;mo&gt;)&lt;/mo&gt;&lt;/mrow&gt;&lt;/mrow&gt;
            &lt;mo&gt;=&lt;/mo&gt;
-           &lt;mfenced open="[" close="]"&gt;&lt;mn&gt;-1&lt;/mn&gt;&lt;mn&gt;1&lt;/mn&gt;&lt;/mfenced&gt;
+           &lt;mrow&gt;&lt;mo&gt;[&lt;/mo&gt;&lt;mn&gt;-1&lt;/mn&gt;&lt;mo&gt;,&lt;/mo&gt;&lt;mn&gt;1&lt;/mn&gt;&lt;mo&gt;]&lt;/mo&gt;&lt;/mrow&gt;
          &lt;/mrow&gt;
        </pre>
       </div>
@@ -4361,7 +4365,7 @@
              &lt;mrow&gt;
                &lt;msup&gt;&lt;mi&gt;y&lt;/mi&gt;&lt;mn&gt;3&lt;/mn&gt;&lt;/msup&gt;
                &lt;mo&gt;&amp;#x2208;&lt;/mo&gt;
-               &lt;mfenced open="[" close="]"&gt;&lt;mn&gt;0&lt;/mn&gt;&lt;mn&gt;1&lt;/mn&gt;&lt;/mfenced&gt;
+               &lt;mrow&gt;&lt;mo&gt;[&lt;/mo&gt;&lt;mn&gt;0&lt;/mn&gt;&lt;mo&gt;,&lt;/mo&gt;&lt;mn&gt;1&lt;/mn&gt;&lt;mo&gt;]&lt;/mo&gt;&lt;/mrow&gt;
              &lt;/mrow&gt;
              &lt;mo&gt;}&lt;/mo&gt;
            &lt;/mrow&gt;
@@ -4923,7 +4927,7 @@
          &lt;mrow&gt;
            &lt;mi&gt;gcd&lt;/mi&gt;
            &lt;mo&gt;&amp;#x2061;&lt;/mo&gt;
-           &lt;mfenced&gt;&lt;mi&gt;a&lt;/mi&gt;&lt;mi&gt;b&lt;/mi&gt;&lt;mi&gt;c&lt;/mi&gt;&lt;/mfenced&gt;
+           &lt;mrow&gt;&lt;mo&gt;(&lt;/mo&gt;&lt;mi&gt;a&lt;/mi&gt;&lt;mo&gt;,&lt;/mo&gt;&lt;mi&gt;b&lt;/mi&gt;&lt;mo&gt;,&lt;/mo&gt;&lt;mi&gt;c&lt;/mi&gt;&lt;mo&gt;)&lt;/mo&gt;&lt;/mrow&gt;
          &lt;/mrow&gt;
        </pre>
       </div>
@@ -5436,13 +5440,15 @@
            &lt;mo&gt;&amp;#x2200;&lt;/mo&gt;
            &lt;mi&gt;x&lt;/mi&gt;
            &lt;mo&gt;.&lt;/mo&gt;
-           &lt;mfenced&gt;
+           &lt;mrow&gt;
+	    &lt;mo&gt;(&lt;/mo&gt;
              &lt;mrow&gt;
                &lt;mrow&gt;&lt;mi&gt;x&lt;/mi&gt;&lt;mo&gt;&amp;#x2212;&lt;/mo&gt;&lt;mi&gt;x&lt;/mi&gt;&lt;/mrow&gt;
                &lt;mo&gt;=&lt;/mo&gt;
                &lt;mn&gt;0&lt;/mn&gt;
              &lt;/mrow&gt;
-           &lt;/mfenced&gt;
+	     &lt;mo&gt;)&lt;/mo&gt;
+           &lt;/mrow&gt;
          &lt;/mrow&gt;
        </pre>
       </div>
@@ -5518,13 +5524,15 @@
            &lt;mo&gt;&amp;#x2203;&lt;/mo&gt;
            &lt;mi&gt;x&lt;/mi&gt;
            &lt;mo&gt;.&lt;/mo&gt;
-           &lt;mfenced&gt;
+           &lt;mrow&gt;
+	    &lt;mo&gt;(&lt;/mo&gt;
              &lt;mrow&gt;
                &lt;mrow&gt;&lt;mi&gt;f&lt;/mi&gt;&lt;mo&gt;&amp;#x2061;&lt;/mo&gt;&lt;mrow&gt;&lt;mo&gt;(&lt;/mo&gt;&lt;mi&gt;x&lt;/mi&gt;&lt;mo&gt;)&lt;/mo&gt;&lt;/mrow&gt;&lt;/mrow&gt;
                &lt;mo&gt;=&lt;/mo&gt;
                &lt;mn&gt;0&lt;/mn&gt;
              &lt;/mrow&gt;
-           &lt;/mfenced&gt;
+	     &lt;mo&gt;)&lt;/mo&gt;
+           &lt;/mrow&gt;
          &lt;/mrow&gt;
        </pre>
       </div>
@@ -5785,13 +5793,15 @@
          &lt;mrow&gt;
            &lt;mi&gt;arg&lt;/mi&gt;
            &lt;mo&gt;&amp;#x2061;&lt;/mo&gt;
-           &lt;mfenced&gt;
+           &lt;mrow&gt;
+	    &lt;mo&gt;(&lt;/mo&gt;
              &lt;mrow&gt;
                &lt;mi&gt;x&lt;/mi&gt;
                &lt;mo&gt;+&lt;/mo&gt;
                &lt;mrow&gt;&lt;mi&gt;i&lt;/mi&gt;&lt;mo&gt;&amp;#x2062;&lt;/mo&gt;&lt;mi&gt;y&lt;/mi&gt;&lt;/mrow&gt;
              &lt;/mrow&gt;
-           &lt;/mfenced&gt;
+	     &lt;mo&gt;)&lt;/mo&gt;
+	   &lt;/mrow&gt;
          &lt;/mrow&gt;
        </pre>
       </div>
@@ -6004,7 +6014,7 @@
          &lt;mrow&gt;
            &lt;mi&gt;lcm&lt;/mi&gt;
            &lt;mo&gt;&amp;#x2061;&lt;/mo&gt;
-           &lt;mfenced&gt;&lt;mi&gt;a&lt;/mi&gt;&lt;mi&gt;b&lt;/mi&gt;&lt;mi&gt;c&lt;/mi&gt;&lt;/mfenced&gt;
+           &lt;mrow&gt;&lt;mo&gt;(&lt;/mo&gt;&lt;mi&gt;a&lt;/mi&gt;&lt;mo&gt;,&lt;/mo&gt;&lt;mi&gt;b&lt;/mi&gt;&lt;mo&gt;,&lt;/mo&gt;&lt;mi&gt;c&lt;/mi&gt;&lt;mo&gt;)&lt;/mo&gt;&lt;/mrow&gt;
          &lt;/mrow&gt;
        </pre>
       </div>
@@ -7132,7 +7142,7 @@
              &lt;mrow&gt;
                &lt;mi&gt;f&lt;/mi&gt;
                &lt;mo&gt;&amp;#x2061;&lt;/mo&gt;
-               &lt;mfenced&gt;&lt;mi&gt;x&lt;/mi&gt;&lt;mi&gt;y&lt;/mi&gt;&lt;/mfenced&gt;
+               &lt;mrow&gt;&lt;mo&gt;(&lt;/mo&gt;&lt;mi&gt;x&lt;/mi&gt;&lt;mo&gt;,&lt;/mo&gt;&lt;mi&gt;y&lt;/mi&gt;&lt;mo&gt;)&lt;/mo&gt;&lt;/mrow&gt;
              &lt;/mrow&gt;
            &lt;/mrow&gt;
            &lt;mrow&gt;
@@ -7397,7 +7407,7 @@
       <div class="example mathml">
        <pre>
          &lt;mrow&gt;
-           &lt;mi&gt;grad&lt;/mi&gt;&lt;mo&gt;&amp;#x2061;&lt;/mo&gt;&lt;mfenced&gt;&lt;mi&gt;f&lt;/mi&gt;&lt;/mfenced&gt;
+           &lt;mi&gt;grad&lt;/mi&gt;&lt;mo&gt;&amp;#x2061;&lt;/mo&gt;&lt;mrow&gt;&lt;mo&gt;(&lt;/mo&gt;&lt;mi&gt;f&lt;/mi&gt;&lt;mo&gt;)&lt;/mo&gt;&lt;/mrow&gt;
          &lt;/mrow&gt;
        </pre>
       </div>
@@ -7410,7 +7420,7 @@
        <pre>
          &lt;mrow&gt;
            &lt;mo&gt;&amp;#x2207;&lt;/mo&gt;&lt;mo&gt;&amp;#x2061;&lt;/mo&gt;
-           &lt;mfenced&gt;&lt;mi&gt;f&lt;/mi&gt;&lt;/mfenced&gt;
+           &lt;mrow&gt;&lt;mo&gt;(&lt;/mo&gt;&lt;mi&gt;f&lt;/mi&gt;&lt;mo&gt;)&lt;/mo&gt;&lt;/mrow&gt;
          &lt;/mrow&gt;
        </pre>
       </div>
@@ -7449,7 +7459,7 @@
            &lt;mo&gt;&amp;#x2061;&lt;/mo&gt;
            &lt;mrow&gt;
              &lt;mo&gt;(&lt;/mo&gt;
-             &lt;mfenced&gt;&lt;mi&gt;x&lt;/mi&gt;&lt;mi&gt;y&lt;/mi&gt;&lt;mi&gt;z&lt;/mi&gt;&lt;/mfenced&gt;
+             &lt;mrow&gt;&lt;mo&gt;(&lt;/mo&gt;&lt;mi&gt;x&lt;/mi&gt;&lt;mo&gt;,&lt;/mo&gt;&lt;mi&gt;y&lt;/mi&gt;&lt;mo&gt;,&lt;/mo&gt;&lt;mi&gt;z&lt;/mi&gt;&lt;mo&gt;)&lt;/mo&gt;&lt;/mrow&gt;
              &lt;mo&gt;&amp;#x21a6;&lt;/mo&gt;
              &lt;mrow&gt;
                &lt;mi&gt;x&lt;/mi&gt;&lt;mo&gt;&amp;#x2062;&lt;/mo&gt;&lt;mi&gt;y&lt;/mi&gt;&lt;mo&gt;&amp;#x2062;&lt;/mo&gt;&lt;mi&gt;z&lt;/mi&gt;
@@ -7514,7 +7524,7 @@
 
       <div class="example mathml">
        <pre>
-         &lt;mrow&gt;&lt;mi&gt;curl&lt;/mi&gt;&lt;mo&gt;&amp;#x2061;&lt;/mo&gt;&lt;mfenced&gt;&lt;mi&gt;a&lt;/mi&gt;&lt;/mfenced&gt;&lt;/mrow&gt;
+         &lt;mrow&gt;&lt;mi&gt;curl&lt;/mi&gt;&lt;mo&gt;&amp;#x2061;&lt;/mo&gt;&lt;mrow&gt;&lt;mo&gt;(&lt;/mo&gt;&lt;mi&gt;a&lt;/mi&gt;&lt;mo&gt;)&lt;/mo&gt;&lt;/mrow&gt;&lt;/mrow&gt;
        </pre>
       </div>
 
@@ -7591,7 +7601,7 @@
          &lt;mrow&gt;
            &lt;msup&gt;&lt;mo&gt;&amp;#x2207;&lt;/mo&gt;&lt;mn&gt;2&lt;/mn&gt;&lt;/msup&gt;
            &lt;mo&gt;&amp;#x2061;&lt;/mo&gt;
-           &lt;mfenced&gt;&lt;mi&gt;E&lt;/mi&gt;&lt;/mfenced&gt;
+           &lt;mrow&gt;&lt;mo&gt;(&lt;/mo&gt;&lt;mi&gt;E&lt;/mi&gt;&lt;mo&gt;)&lt;/mo&gt;&lt;/mrow&gt;
          &lt;/mrow&gt;
        </pre>
       </div>
@@ -7629,12 +7639,12 @@
            &lt;mo&gt;&amp;#x2061;&lt;/mo&gt;
            &lt;mrow&gt;
              &lt;mo&gt;(&lt;/mo&gt;
-             &lt;mfenced&gt;&lt;mi&gt;x&lt;/mi&gt;&lt;mi&gt;y&lt;/mi&gt;&lt;mi&gt;z&lt;/mi&gt;&lt;/mfenced&gt;
+             &lt;mrow&gt;&lt;mo&gt;(&lt;/mo&gt;&lt;mi&gt;x&lt;/mi&gt;&lt;mo&gt;,&lt;/mo&gt;&lt;mi&gt;y&lt;/mi&gt;&lt;mo&gt;,&lt;/mo&gt;&lt;mi&gt;z&lt;/mi&gt;&lt;mo&gt;)&lt;/mo&gt;&lt;/mrow&gt;
              &lt;mo&gt;&amp;#x21a6;&lt;/mo&gt;
              &lt;mrow&gt;
                &lt;mi&gt;f&lt;/mi&gt;
                &lt;mo&gt;&amp;#x2061;&lt;/mo&gt;
-               &lt;mfenced&gt;&lt;mi&gt;x&lt;/mi&gt;&lt;mi&gt;y&lt;/mi&gt;&lt;/mfenced&gt;
+               &lt;mrow&gt;&lt;mo&gt;(&lt;/mo&gt;&lt;mi&gt;x&lt;/mi&gt;&lt;mo&gt;,&lt;/mo&gt;&lt;mi&gt;y&lt;/mi&gt;&lt;mo&gt;)&lt;/mo&gt;&lt;/mrow&gt;
              &lt;/mrow&gt;
              &lt;mo&gt;)&lt;/mo&gt;
            &lt;/mrow&gt;
@@ -9933,7 +9943,7 @@
          &lt;mrow&gt;
            &lt;mo&gt;&amp;#x3c3;&lt;/mo&gt;
            &lt;mo&gt;&amp;#x2061;&lt;/mo&gt;
-           &lt;mfenced&gt;&lt;mn&gt;3&lt;/mn&gt;&lt;mn&gt;4&lt;/mn&gt;&lt;mn&gt;2&lt;/mn&gt;&lt;mn&gt;2&lt;/mn&gt;&lt;/mfenced&gt;
+           &lt;mrow&gt;&lt;mo&gt;(&lt;/mo&gt;&lt;mn&gt;3&lt;/mn&gt;&lt;mo&gt;,&lt;/mo&gt;&lt;mn&gt;4&lt;/mn&gt;&lt;mo&gt;,&lt;/mo&gt;&lt;mn&gt;2&lt;/mn&gt;&lt;mo&gt;,&lt;/mo&gt;&lt;mn&gt;2&lt;/mn&gt;&lt;mo&gt;)&lt;/mo&gt;&lt;/mrow&gt;
          &lt;/mrow&gt;
        </pre>
       </div>
@@ -10031,7 +10041,7 @@
              &lt;mn&gt;2&lt;/mn&gt;
            &lt;/msup&gt;
            &lt;mo&gt;&amp;#x2061;&lt;/mo&gt;
-           &lt;mfenced&gt;&lt;mn&gt;3&lt;/mn&gt;&lt;mn&gt;4&lt;/mn&gt;&lt;mn&gt;2&lt;/mn&gt;&lt;mn&gt;2&lt;/mn&gt;&lt;/mfenced&gt;
+           &lt;mrow&gt;&lt;mo&gt;(&lt;/mo&gt;&lt;mn&gt;3&lt;/mn&gt;&lt;mo&gt;,&lt;/mo&gt;&lt;mn&gt;4&lt;/mn&gt;&lt;mo&gt;,&lt;/mo&gt;&lt;mn&gt;2&lt;/mn&gt;&lt;mo&gt;,&lt;/mo&gt;&lt;mn&gt;2&lt;/mn&gt;&lt;mo&gt;)&lt;/mo&gt;&lt;/mrow&gt;
          &lt;/mrow&gt;
        </pre>
       </div>
@@ -10128,7 +10138,7 @@
          &lt;mrow&gt;
            &lt;mi&gt;median&lt;/mi&gt;
            &lt;mo&gt;&amp;#x2061;&lt;/mo&gt;
-           &lt;mfenced&gt;&lt;mn&gt;3&lt;/mn&gt;&lt;mn&gt;4&lt;/mn&gt;&lt;mn&gt;2&lt;/mn&gt;&lt;mn&gt;2&lt;/mn&gt;&lt;/mfenced&gt;
+           &lt;mrow&gt;&lt;mo&gt;(&lt;/mo&gt;&lt;mn&gt;3&lt;/mn&gt;&lt;mo&gt;,&lt;/mo&gt;&lt;mn&gt;4&lt;/mn&gt;&lt;mo&gt;,&lt;/mo&gt;&lt;mn&gt;2&lt;/mn&gt;&lt;mo&gt;,&lt;/mo&gt;&lt;mn&gt;2&lt;/mn&gt;&lt;mo&gt;)&lt;/mo&gt;&lt;/mrow&gt;
          &lt;/mrow&gt;
        </pre>
       </div>

--- a/src/contm-new.html
+++ b/src/contm-new.html
@@ -10541,13 +10541,13 @@
              &lt;mrow&gt;
                &lt;mi&gt;i&lt;/mi&gt;
                &lt;mo&gt;&amp;#x2208;&lt;/mo&gt;
-               &lt;mfenced open="[" close="]"&gt;&lt;mi&gt;1&lt;/mi&gt;&lt;mi&gt;5&lt;/mi&gt;&lt;/mfenced&gt;
+               &lt;mrow&gt;&lt;mo&gt;[&lt;/mo&gt;&lt;mi&gt;1&lt;/mi&gt;&lt;mo&gt;,&lt;/mo&gt;&lt;mi&gt;5&lt;/mi&gt;&lt;mo&gt;]&lt;/mo&gt;&lt;/mrow&gt;
              &lt;/mrow&gt;
              &lt;mo&gt;&amp;#x2227;&lt;/mo&gt;
              &lt;mrow&gt;
                &lt;mi&gt;j&lt;/mi&gt;
                &lt;mo&gt;&amp;#x2208;&lt;/mo&gt;
-               &lt;mfenced open="[" close="]"&gt;&lt;mi&gt;5&lt;/mi&gt;&lt;mi&gt;9&lt;/mi&gt;&lt;/mfenced&gt;
+               &lt;mrow&gt;&lt;mo&gt;[&lt;/mo&gt;&lt;mi&gt;5&lt;/mi&gt;&lt;mo&gt;,&lt;/mo&gt;&lt;mi&gt;9&lt;/mi&gt;&lt;mo&gt;]&lt;/mo&gt;&lt;/mrow&gt;
              &lt;/mrow&gt;
            &lt;/mrow&gt;
            &lt;mo&gt;]&lt;/mo&gt;

--- a/src/mixing.html
+++ b/src/mixing.html
@@ -289,7 +289,7 @@ as an embellished symbol would be distinguished as follows:</p>
              &lt;mrow&gt;
                &lt;mi&gt;sin&lt;/mi&gt;
                &lt;mo&gt;&amp;ApplyFunction;&lt;/mo&gt;
-               &lt;mfenced open="(" close=")"&gt;&lt;mi&gt;x&lt;/mi&gt;&lt;/mfenced&gt;
+               &lt;mrow&gt;&lt;mo&gt;(&lt;/mo&gt;&lt;mi&gt;x&lt;/mi&gt;&lt;mo&gt;)&lt;/mo&gt;&lt;/mrow&gt;
              &lt;/mrow&gt;
              &lt;mo&gt;+&lt;/mo&gt;
              &lt;mn&gt;5&lt;/mn&gt;
@@ -351,9 +351,11 @@ as an embellished symbol would be distinguished as follows:</p>
          &lt;mrow&gt;
            &lt;mrow&gt;
              &lt;mi&gt;a&lt;/mi&gt;
-             &lt;mfenced open="(" close=")"&gt;
+             &lt;mrow&gt;
+               &lt;mo&gt;(&lt;/mo&gt;
                &lt;mrow&gt;&lt;mi&gt;x&lt;/mi&gt;&lt;mo&gt;+&lt;/mo&gt;&lt;mn&gt;5&lt;/mn&gt;&lt;/mrow&gt;
-             &lt;/mfenced&gt;
+               &lt;mo&gt;)&lt;/mo&gt;
+             &lt;/mrow&gt;
            &lt;/mrow&gt;
          &lt;/mrow&gt;
          &lt;annotation-xml cd="mathmlkeys" name="contentequiv" encoding="MathML-Content"&gt;
@@ -448,7 +450,7 @@ as an embellished symbol would be distinguished as follows:</p>
             &lt;mrow&gt;
               &lt;mi&gt;sin&lt;/mi&gt;
               &lt;mo&gt;&amp;ApplyFunction;&lt;/mo&gt;
-              &lt;mfenced&gt;&lt;mi&gt;x&lt;/mi&gt;&lt;/mfenced&gt;
+              &lt;mrow&gt;&lt;mo&gt;(&lt;/mo&gt;&lt;mi&gt;x&lt;/mi&gt;&lt;mo&gt;)&lt;/mo&gt;&lt;/mrow&gt;
             &lt;/mrow&gt;
             &lt;mo&gt;+&lt;/mo&gt;
             &lt;mn&gt;5&lt;/mn&gt;

--- a/src/transform2strict.html
+++ b/src/transform2strict.html
@@ -1753,9 +1753,11 @@
              &lt;mrow&gt;&lt;mo&gt;(&lt;/mo&gt;&lt;mi&gt;p&lt;/mi&gt;&lt;mo&gt;&amp;lt;&lt;/mo&gt;&lt;mi&gt;q&lt;/mi&gt;&lt;mo&gt;)&lt;/mo&gt;&lt;/mrow&gt;
            &lt;/mrow&gt;
            &lt;mo&gt;.&lt;/mo&gt;
-           &lt;mfenced&gt;
+           &lt;mrow&gt;
+             &lt;mo&gt;(&lt;/mo&gt;
              &lt;mrow&gt;&lt;mi&gt;p&lt;/mi&gt;&lt;mo&gt;&amp;lt;&lt;/mo&gt;&lt;msup&gt;&lt;mi&gt;q&lt;/mi&gt;&lt;mn&gt;2&lt;/mn&gt;&lt;/msup&gt;&lt;/mrow&gt;
-           &lt;/mfenced&gt;
+             &lt;mo&gt;)&lt;/mo&gt;
+           &lt;/mrow&gt;
          &lt;/mrow&gt;
        </pre>
       </div>
@@ -1770,7 +1772,8 @@
            &lt;mo&gt;&amp;#x2200;&lt;/mo&gt;
            &lt;mrow&gt;&lt;mi&gt;p&lt;/mi&gt;&lt;mo&gt;,&lt;/mo&gt;&lt;mi&gt;q&lt;/mi&gt;&lt;/mrow&gt;
            &lt;mo&gt;.&lt;/mo&gt;
-           &lt;mfenced&gt;
+           &lt;mrow&gt;
+             &lt;mo&gt;(&lt;/mo&gt;
              &lt;mrow&gt;
                &lt;mrow&gt;
                  &lt;mo&gt;(&lt;/mo&gt;
@@ -1794,7 +1797,8 @@
                  &lt;mo&gt;)&lt;/mo&gt;
                &lt;/mrow&gt;
              &lt;/mrow&gt;
-           &lt;/mfenced&gt;
+             &lt;mo&gt;)&lt;/mo&gt;
+           &lt;/mrow&gt;
          &lt;/mrow&gt;
        </pre>
       </div>


### PR DESCRIPTION
This PR removes `<mfenced>` from the sample presentations in chapter 4, making them potentially viewable with mathml core