### PR TITLE
inline mathml rendering in respec drafts

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,7 +75,18 @@
     }
     function resortable () {
         sorttable.makeSortable(document.getElementById('oper-dict-table'));
-      }
+    }
+    function showcore (){
+	var mmllist=document.querySelectorAll("div.example.mathml");
+	for(var i=0;i!=mmllist.length;i++){
+	    var m=document.createElementNS("http://www.w3.org/1998/Math/MathML","math");;
+	    m.setAttribute("display","block");
+	    m.setAttribute("class","inlinemath removeOnSave");
+	    m.innerHTML=mmllist[i].textContent;
+	    mmllist[i].parentNode.insertBefore(m,mmllist[i].nextSibling);
+	}
+    }
+	
       </script>
   <script class='remove'>
    var respecConfig = {
@@ -92,15 +103,15 @@
      shortName:     "MathML4",
      maxTocLevel:   4,
      otherLinks:    [{
-      key: "Latest MathML Recommendation",
-      data: [{
-              value: "https://www.w3.org/TR/MathML/",
-              href: "https://www.w3.org/TR/MathML/",
-            }]
-                    }],
-     github:        "https://github.com/w3c/mathml",
-     postProcess:   [mmlindex,foldable,resortable],
-     localBiblio: {     
+     key: "Latest MathML Recommendation",
+     data: [{
+             value: "https://www.w3.org/TR/MathML/",
+             href: "https://www.w3.org/TR/MathML/",
+           }]
+                   }],
+  github:        "https://github.com/w3c/mathml",
+       postProcess:   [mmlindex,foldable,resortable,showcore],
+  localBiblio: {
   "MathML1":           {"aliasOf": "MathML-19980407"},
   "MathML-Core":       {"aliasOf": "mathml-core"},
   "Entities":          {"aliasOf": "xml-entity-names"},
@@ -213,6 +224,13 @@ border-color:var(--example-border);
 border-left-style: solid;
 //background: var(--example-bg);
 background: #fafafa;
+}
+math.inlinemath {
+    border-width: .5em;
+    border-left-style: solid;
+    border-color: lightgreen;
+    background-color: #F7FFF6;
+    padding:1em;
 }
 #references :target{background:white;animation:none;}
   </style>


### PR DESCRIPTION
This (fixed) PR adds inline mathml after core mathml examples, styled with a thick left border to match the current w3c /respec styling.
The rendered `<math>`  is removed on save so would not appear in official WD or REC versions but appears in editor's drafts with live respec processing.

I think it's a useful test that the examples actually are examples, when adding `&lt;` quoted mathml inside an html div it's easy to get something wrong, and this provides immediate feedback.

![image](https://user-images.githubusercontent.com/1268738/161375636-cbf5b40f-084d-41df-9e59-b91b0c6ed424.png)
