### PR TITLE
Remove references and text for deprecated features.

### DIFF
--- a/src/presentation-markup.html
+++ b/src/presentation-markup.html
@@ -1234,11 +1234,6 @@
      </tbody>
     </table>
 
-    <p>Note that the <code class="attribute">src</code> and <code class="attribute">alt</code> attributes are <em>required</em> for correct usage in MathML 3, however this is not enforced by the schema due to
-    the <a class="intref" href="#presm_mglyph_deprecated">deprecated usage described below</a>.</p>
-
-   </section>
-
    <section class="fold">
     <h6>Example</h6>
 
@@ -1265,66 +1260,6 @@
 
    </section>
 
-   <section>
-    <h6 id="presm_mglyph_deprecated">Deprecated Attributes</h6>
-
-    <p>Originally, <code class="element">mglyph</code> was designed to provide access to non-standard
-    fonts. Since this functionality was seldom implemented, nor were downloadable
-    web fonts widely available, this use of <code class="element">mglyph</code> has been deprecated.
-    For reference, the following attributes were previously defined:
-
-    <table class="attributes data">
-
-     <thead>
-
-      <tr>
-       <td>Name</td>
-       <td>values</td>
-       <td>Core</td>
-      </tr>
-     </thead>
-
-     <tbody>
-
-      <tr>
-       <td rowspan="2" class="attname">fontfamily</td>
-       <td><a class="intref" href="#type_string"><em>string</em></a></td>
-       <td><span class="coreno"></span></td>
-      </tr>
-
-      <tr>
-       <td colspan="2" class="attdesc">
-        the name of a font that may be available to a MathML renderer,
-        or a CSS font specification; See  <a href="#world-int-style"></a>
-        and CSS [[CSS21]] for more information.
-       </td>
-      </tr>
-
-      <tr>
-       <td rowspan="2" class="attname">index</td>
-       <td><a class="intref" href="#type_integer"><em>integer</em></a></td>
-       <td><span class="coreno"></span></td>
-      </tr>
-
-      <tr>
-       <td colspan="2" class="attdesc">
-        Specified a position of the desired glyph within the font named
-        by the <code class="attribute">fontfamily</code> attribute (see <a href="#presm_deprecatt"></a>).
-       </td>
-      </tr>
-     </tbody>
-    </table>
-    In MathML 1 and 2, both were required attributes; they are now optional
-    and should be ignored unless the <code class="attribute">src</code> attribute is missing.
-    </p>
-
-    <p>Additionally, in MathML 2, <code class="element">mglyph</code> accepted the attributes described in
-    <a href="#presm_commatt"></a>
-    (<code class="attribute">mathvariant</code> and <code class="attribute">mathsize</code>, along with the attributes deprecated there);
-    to make clear that <code class="element">mglyph</code> is <em>not</em> a token element, and since
-    these attributes have no effect in any case, these attributes have been deprecated.
-    </p>
-   </section>
   </section>
 
  </section>
@@ -1508,127 +1443,6 @@
   most intelligible, highest quality rendering.
   Note that many MathML elements automatically change the font size
   in some of their children; see the discussion in <a href="#presm_scriptlevel"></a>.</p>
-
-  <section>
-    <div class="issue" data-number="303"></div>
-   <h5 id="presm_deprecatt">Deprecated style attributes on token elements <span class="coreno"></span></h5>
-
-   <p>The MathML 1.01 style attributes listed below
-   are <a class="intref" href="#interf_deprec">deprecated</a> in MathML 2 and 3.
-   These attributes were aligned to CSS <span>but,</span> in rendering environments that support CSS,
-   it is preferable to use CSS directly to control the rendering properties
-   corresponding to these attributes, rather than the attributes themselves.
-   However as explained above, direct manipulation of these
-   rendering properties by whatever means should usually be avoided.
-   As a general rule, whenever there is a conflict between these
-   deprecated attributes and the corresponding attributes (<a href="#presm_commatt"></a>),
-   the former attributes should be ignored.</p>
-
-   <p>The deprecated attributes are:
-
-   <table class="attributes data">
-
-    <thead>
-
-     <tr>
-      <td>Name</td>
-      <td>values</td>
-      <td>default</td>
-      <td>Core</td>
-     </tr>
-    </thead>
-
-    <tbody>
-
-     <tr>
-      <td rowspan="2" class="attname">fontfamily</td>
-      <td><a class="intref" href="#type_string"><em>string</em></a></td>
-      <td><em>inherited</em></td>
-      <td><span class="coreno"></span></td>
-     </tr>
-
-     <tr>
-      <td colspan="3" class="attdesc">
-       Should be the name of a font that may be available to a MathML renderer,
-       or a CSS font specification; See  <a href="#world-int-style"></a>
-       and CSS [[CSS21]] for more information.
-       Deprecated in favor of <code class="attribute">mathvariant</code>.
-      </td>
-     </tr>
-
-     <tr>
-      <td rowspan="2" class="attname">fontweight</td>
-      <td>"normal" | "bold"</td>
-      <td><em>inherited</em></td>
-      <td><span class="coreno"></span></td>
-     </tr>
-
-     <tr>
-      <td colspan="3" class="attdesc">
-       Specified the font weight for the token.
-       Deprecated in favor of <code class="attribute">mathvariant</code>.
-      </td>
-     </tr>
-
-     <tr>
-      <td rowspan="2" class="attname">fontstyle</td>
-      <td>"normal" | "italic"</td>
-      <td>normal (<em>except on</em> <code class="starttag">&lt;mi&gt;</code>)</td>
-      <td><span class="coreno"></span></td>
-     </tr>
-
-     <tr>
-      <td colspan="3" class="attdesc">
-       Specified the font style to use for the token.
-       Deprecated in favor of <code class="attribute">mathvariant</code>.
-      </td>
-     </tr>
-
-     <tr>
-      <td rowspan="2" class="attname">fontsize</td>
-      <td><a class="intref" href="#type_length"><em>length</em></a></td>
-      <td><em>inherited</em></td>
-      <td><span class="coreno"></span></td>
-     </tr>
-
-     <tr>
-      <td colspan="3" class="attdesc">
-       Specified the size for the token.
-       Deprecated in favor of <code class="attribute">mathsize</code>.
-      </td>
-     </tr>
-
-     <tr>
-      <td rowspan="2" class="attname">color</td>
-      <td><a class="intref" href="#type_color"><em>color</em></a></td>
-      <td><em>inherited</em></td>
-      <td><span class="coreno"></span></td>
-     </tr>
-
-     <tr>
-      <td colspan="3" class="attdesc">
-       Specified the color for the token.
-       Deprecated in favor of <code class="attribute">mathcolor</code>.
-      </td>
-     </tr>
-
-     <tr>
-      <td rowspan="2" class="attname">background</td>
-      <td><a class="intref" href="#type_color"><em>color</em></a> | "transparent"</td>
-      <td>transparent</td>
-      <td><span class="coreno"></span></td>
-     </tr>
-
-     <tr>
-      <td colspan="3" class="attdesc">
-       Specified the background color to be used to fill in the bounding box
-       of the element and its children. Deprecated in favor of <code class="attribute">mathbackground</code>.
-      </td>
-     </tr>
-    </tbody>
-   </table>
-   </p>
-  </section>
 
   <section>
    <h5 id="presm_html_insertion">Embedding HTML in MathML</h5>
@@ -3694,9 +3508,6 @@ listed in
 </p>
 
 <p>
- The value <code class="attributevalue">indentingnewline</code> was defined in MathML2 for <code class="element">mspace</code>;
- it is now deprecated.  Its meaning is the same as <code class="attribute">newline</code>, which is compatible with its earlier use when no other linebreaking attributes are
- specified.
  Note that <code class="attribute">linebreak</code> values on adjacent <code class="element">mo</code> and <code class="element">mspace</code> elements do
  not interact; a <code class="attributevalue">nobreak</code> on an <code class="element">mspace</code> will
  not, in itself, inhibit a break on an adjacent <code class="element">mo</code> element.
@@ -6965,9 +6776,6 @@ section on &lt;mo&gt;,
 
    <p>A matrix or table is specified using the <code class="element">mtable</code> element. Inside of the <code class="element">mtable</code> element, only <code class="element">mtr</code>
    or <code class="element">mlabeledtr</code> elements may appear.
-   (In MathML 1.x, the <code class="element">mtable</code> was allowed to &#x2018;infer&#x2019; <code class="element">mtr</code> elements around its arguments,
-   and the <code class="element">mtr</code> element could infer <code class="element">mtd</code> elements.
-   This behaviour is <a class="intref" href="#interf_deprec">deprecated</a>.)
    </p>
 
    <p>Table rows that have fewer columns than other rows of the same


### PR DESCRIPTION
Note: I removed the text
> Note that the src and alt attributes are required for correct usage in MathML 3, however this is not enforced by the schema due to the [deprecated usage described below](https://w3c.github.io/mathml/#presm_mglyph_deprecated).

It seemed like this is no longer a reason to keep them out of the schema.