### PR TITLE
compress arthmetic constants section.

### DIFF
--- a/src/contm-new.html
+++ b/src/contm-new.html
@@ -7520,7 +7520,7 @@
 represent respectively:<br/>
 the base of the natural logarithm, approximately 2.718;<br/>
 the square root of -1, commonly written <i>i</i>;<br/>
-not-a-number, i.e. the result of an ill-posed floating point computation. See [[IEEE754]].<br/>
+not-a-number, i.e. the result of an ill-posed floating point computation (see [[IEEE754]]);<br/>
 the Boolean value true;<br/>
 the Boolean value false;<br/>
 pi (<i>&#x03c0;</i>), approximately 3.142, which is the ratio of the circumference of a circle to its diameter;<br/>

--- a/src/contm-new.html
+++ b/src/contm-new.html
@@ -7508,18 +7508,65 @@
 
 
 
-     <p>This element represents the base of the natural logarithm, approximately 2.718.</p>
+     <p>The elements
+<code class="defn emptytag">&lt;exponentiale/&gt;</code>,
+<code class="defn emptytag">&lt;imaginaryi/&gt;</code>,
+<code class="defn emptytag">&lt;notanumber/&gt;</code>,
+<code class="defn emptytag">&lt;true/&gt;</code>,
+<code class="defn emptytag">&lt;false/&gt;</code>,
+<code class="defn emptytag">&lt;pi/&gt;</code>,
+<code class="defn emptytag">&lt;eulergamma/&gt;</code>,
+<code class="defn emptytag">&lt;infinity/&gt;</code>
+represent respectively:<br/>
+the base of the natural logarithm, approximately 2.718;<br/>
+the square root of -1, commonly written <i>i</i>;<br/>
+not-a-number, i.e. the result of an ill-posed floating point computation. See [[IEEE754]].<br/>
+the Boolean value true;<br/>
+the Boolean value false;<br/>
+pi (<i>&#x03c0;</i>), approximately 3.142, which is the ratio of the circumference of a circle to its diameter;<br/>
+the gamma constant (<i>&#x03b3;</i>), approximately 0.5772;<br/>
+infinity (&#x221e;).</p>
 
-     <div id="nums1.exponentiale.ex1" class="mathml-example">
+<div id="nums1.constants.ex1" class="mathml-example">
       <p>Content MathML</p>
 
       <div class="example mathml mml4c">
        <pre>
-         &lt;apply&gt;&lt;eq/&gt;
-           &lt;apply&gt;&lt;ln/&gt;&lt;exponentiale/&gt;&lt;/apply&gt;
-           &lt;cn&gt;1&lt;/cn&gt;
-         &lt;/apply&gt;
+         &lt;apply&gt;&lt;eq/&gt;&lt;apply&gt;&lt;ln/&gt;&lt;exponentiale/&gt;&lt;/apply&gt;&lt;cn&gt;1&lt;/cn&gt;&lt;/apply&gt;
        </pre>
+      </div>
+      <div class="example mathml mml4c">
+       <pre>
+         &lt;apply&gt;&lt;eq/&gt;&lt;apply&gt;&lt;power/&gt;&lt;imaginaryi/&gt;&lt;cn&gt;2&lt;/cn&gt;&lt;/apply&gt;&lt;cn&gt;-1&lt;/cn&gt;&lt;/apply&gt;
+       </pre>
+      </div>
+      <div class="example mathml mml4c">
+       <pre>
+         &lt;apply&gt;&lt;eq/&gt;&lt;apply&gt;&lt;divide/&gt;&lt;cn&gt;0&lt;/cn&gt;&lt;cn&gt;0&lt;/cn&gt;&lt;/apply&gt;&lt;notanumber/&gt;&lt;/apply&gt;
+       </pre>
+      </div>
+      <div class="example mathml mml4c">
+       <pre>
+         &lt;apply&gt;&lt;eq/&gt;&lt;apply&gt;&lt;or/&gt;&lt;true/&gt;&lt;ci type="boolean"&gt;P&lt;/ci&gt;&lt;/apply&gt;&lt;true/&gt;&lt;/apply&gt;
+       </pre>
+      </div>
+      <div class="example mathml mml4c">
+       <pre>
+         &lt;apply&gt;&lt;eq/&gt;&lt;apply&gt;&lt;and/&gt;&lt;false/&gt;&lt;ci type="boolean"&gt;P&lt;/ci&gt;&lt;/apply&gt;&lt;false/&gt;&lt;/apply&gt;
+       </pre>
+      </div>
+      <div class="example mathml mml4c">
+       <pre>
+         &lt;apply&gt;&lt;approx/&gt;&lt;pi/&gt;&lt;cn type="rational"&gt;22&lt;sep/&gt;7&lt;/cn&gt;&lt;/apply&gt;
+       </pre>
+      </div>
+      <div class="example mathml mml4c">
+       <pre>
+         &lt;apply&gt;&lt;approx/&gt;&lt;eulergamma/&gt;&lt;cn&gt;0.5772156649&lt;/cn&gt;&lt;/apply&gt;
+       </pre>
+      </div>
+      <div class="example mathml mml4c">
+       <pre>&lt;infinity/&gt;</pre>
       </div>
 
       <p>Sample Presentation</p>
@@ -7533,60 +7580,11 @@
          &lt;/mrow&gt;
        </pre>
       </div>
-
-      <blockquote>
-       <p><img src="image/nums1-exponentiale-ex1.gif" alt="{{\mathop{{\minormal{ln}}}e}={1}}"></img></p>
-      </blockquote>
-     </div>
-
-     
-
-     <p>This element represents the mathematical constant which is the square root of -1,
-
-     commonly written i</p>
-
-     <div id="nums1.imaginaryi.ex1" class="mathml-example">
-      <p>Content MathML</p>
-
-      <div class="example mathml mml4c">
-       <pre>
-         &lt;apply&gt;&lt;eq/&gt;
-           &lt;apply&gt;&lt;power/&gt;&lt;imaginaryi/&gt;&lt;cn&gt;2&lt;/cn&gt;&lt;/apply&gt;
-           &lt;cn&gt;-1&lt;/cn&gt;
-         &lt;/apply&gt;
-       </pre>
-      </div>
-
-      <p>Sample Presentation</p>
-
       <div class="example mathml mmlcore">
        <pre>
          &lt;mrow&gt;&lt;msup&gt;&lt;mi&gt;i&lt;/mi&gt;&lt;mn&gt;2&lt;/mn&gt;&lt;/msup&gt;&lt;mo&gt;=&lt;/mo&gt;&lt;mn&gt;-1&lt;/mn&gt;&lt;/mrow&gt;
        </pre>
       </div>
-
-      <blockquote>
-       <p><img src="image/nums1-imaginaryi-ex1.gif" alt="{\msup{i}{{2}}={\mn{-1}}}"></img></p>
-      </blockquote>
-     </div>
-     <p>This element represents the notion of not-a-number, i.e. the result of an ill-posed
-
-     floating computation. See [[IEEE754]].</p>
-
-     <div id="nums1.notanumber.ex1" class="mathml-example">
-      <p>Content MathML</p>
-
-      <div class="example mathml mml4c">
-       <pre>
-         &lt;apply&gt;&lt;eq/&gt;
-           &lt;apply&gt;&lt;divide/&gt;&lt;cn&gt;0&lt;/cn&gt;&lt;cn&gt;0&lt;/cn&gt;&lt;/apply&gt;
-           &lt;notanumber/&gt;
-         &lt;/apply&gt;
-       </pre>
-      </div>
-
-      <p>Sample Presentation</p>
-
       <div class="example mathml mmlcore">
        <pre>
          &lt;mrow&gt;
@@ -7596,31 +7594,6 @@
          &lt;/mrow&gt;
        </pre>
       </div>
-
-      <blockquote>
-       <p><img src="image/nums1-notanumber-ex1.gif" alt="{{{0}/{0}}={\minormal{NaN}}}"></img></p>
-      </blockquote>
-     </div>
-
-          <p>This element represents the Boolean value true, i.e. the logical constant for truth.</p>
-
-     <div id="logic1.true.ex1" class="mathml-example">
-      <p>Content MathML</p>
-
-      <div class="example mathml mml4c">
-       <pre>
-         &lt;apply&gt;&lt;eq/&gt;
-           &lt;apply&gt;&lt;or/&gt;
-             &lt;true/&gt;
-             &lt;ci type="boolean"&gt;P&lt;/ci&gt;
-           &lt;/apply&gt;
-           &lt;true/&gt;
-         &lt;/apply&gt;
-       </pre>
-      </div>
-
-      <p>Sample Presentation</p>
-
       <div class="example mathml mmlcore">
        <pre>
          &lt;mrow&gt;
@@ -7630,31 +7603,6 @@
          &lt;/mrow&gt;
        </pre>
       </div>
-
-      <blockquote>
-       <p><img src="image/logic1-true-ex1.gif" alt="{{{\minormal{true}}\unicode{8744}P}={\minormal{true}}}"></img></p>
-      </blockquote>
-     </div>
-
-          <p>This element represents the Boolean value false, i.e. the logical constant for falsehood.</p>
-
-     <div id="logic1.false.ex1" class="mathml-example">
-      <p>Content MathML</p>
-
-      <div class="example mathml mml4c">
-       <pre>
-         &lt;apply&gt;&lt;eq/&gt;
-           &lt;apply&gt;&lt;and/&gt;
-             &lt;false/&gt;
-             &lt;ci type="boolean"&gt;P&lt;/ci&gt;
-           &lt;/apply&gt;
-           &lt;false/&gt;
-         &lt;/apply&gt;
-       </pre>
-      </div>
-
-      <p>Sample Presentation</p>
-
       <div class="example mathml mmlcore">
        <pre>
          &lt;mrow&gt;
@@ -7664,29 +7612,6 @@
          &lt;/mrow&gt;
        </pre>
       </div>
-
-      <blockquote>
-       <p><img src="image/logic1-false-ex1.gif" alt="{{{\minormal{false}}\unicode{8743}P}={\minormal{false}}}"></img></p>
-      </blockquote>
-     </div>
-
-     <p>This element represents pi, approximately 3.142, which is the
-     ratio of the circumference of a circle to its diameter.</p>
-
-     <div id="nums1.pi.ex1" class="mathml-example">
-      <p>Content MathML</p>
-
-      <div class="example mathml mml4c">
-       <pre>
-         &lt;apply&gt;&lt;approx/&gt;
-           &lt;pi/&gt;
-           &lt;cn type="rational"&gt;22&lt;sep/&gt;7&lt;/cn&gt;
-         &lt;/apply&gt;
-       </pre>
-      </div>
-
-      <p>Sample Presentation</p>
-
       <div class="example mathml mmlcore">
        <pre>
          &lt;mrow&gt;
@@ -7696,27 +7621,6 @@
          &lt;/mrow&gt;
        </pre>
       </div>
-
-      <blockquote>
-       <p><img src="image/nums1-pi-ex1.gif" alt="{\unicode{960}\unicode{8771}{{22}/{7}}}"></img></p>
-      </blockquote>
-     </div>
-     <p>This element denotes the gamma constant, approximately 0.5772.</p>
-
-     <div id="nums1.eulergamma.ex1" class="mathml-example">
-      <p>Content MathML</p>
-
-      <div class="example mathml mml4c">
-       <pre>
-         &lt;apply&gt;&lt;approx/&gt;
-           &lt;eulergamma/&gt;
-           &lt;cn&gt;0.5772156649&lt;/cn&gt;
-         &lt;/apply&gt;
-       </pre>
-      </div>
-
-      <p>Sample Presentation</p>
-
       <div class="example mathml mmlcore">
        <pre>
          &lt;mrow&gt;
@@ -7724,36 +7628,63 @@
          &lt;/mrow&gt;
        </pre>
       </div>
-
-      <blockquote>
-       <p><img src="image/nums1-eulergamma-ex1.gif" alt="{\unicode{947}\unicode{8771}{0.5772156649}}"></img></p>
-      </blockquote>
-     </div>
-
-     
-     <p>This element represents the notion of infinity.</p>
-
-     <div id="nums1.infinity.ex1" class="mathml-example">
-      <p>Content MathML</p>
-
-      <div class="example mathml mml4c">
-       <pre>&lt;infinity/&gt;</pre>
-      </div>
-
-      <p>Sample Presentation</p>
-
       <div class="example mathml mmlcore">
        <pre>
          &lt;mi&gt;&amp;#x221e;&lt;/mi&gt;
        </pre>
       </div>
 
+<!--
+      <blockquote>
+       <p><img src="image/nums1-exponentiale-ex1.gif" alt="{{\mathop{{\minormal{ln}}}e}={1}}"></img></p>
+      </blockquote>
+-->
+
+<!--
+      <blockquote>
+       <p><img src="image/nums1-imaginaryi-ex1.gif" alt="{\msup{i}{{2}}={\mn{-1}}}"></img></p>
+      </blockquote>
+-->
+
+<!--
+      <blockquote>
+       <p><img src="image/nums1-notanumber-ex1.gif" alt="{{{0}/{0}}={\minormal{NaN}}}"></img></p>
+      </blockquote>
+-->
+
+
+<!--
+      <blockquote>
+       <p><img src="image/logic1-true-ex1.gif" alt="{{{\minormal{true}}\unicode{8744}P}={\minormal{true}}}"></img></p>
+      </blockquote>
+-->
+
+<!--
+      <blockquote>
+       <p><img src="image/logic1-false-ex1.gif" alt="{{{\minormal{false}}\unicode{8743}P}={\minormal{false}}}"></img></p>
+      </blockquote>
+-->
+<!--
+      <blockquote>
+       <p><img src="image/nums1-pi-ex1.gif" alt="{\unicode{960}\unicode{8771}{{22}/{7}}}"></img></p>
+      </blockquote>
+-->
+
+<!--
+      <blockquote>
+       <p><img src="image/nums1-eulergamma-ex1.gif" alt="{\unicode{947}\unicode{8771}{0.5772156649}}"></img></p>
+      </blockquote>
+-->
+
+<!--
       <blockquote>
        <p><img src="image/nums1-infinity-ex1.gif" alt="\unicode{8734}"></img></p>
       </blockquote>
      </div>
+-->
 
-    </section>
+      </div>
+     </section>
 
     
     <section>

--- a/src/contm-new.html
+++ b/src/contm-new.html
@@ -7706,17 +7706,46 @@ infinity (&#x221e;).</p>
 
 
 
-     <p>This element represents the set of integers, positive, negative and zero.</p>
+     <p>These elements represent the standard number sets,
+       Integers, Reals, Rationals, Natural Numbers (including zero), Complex Numbers, Prime Numbers,
+       and the Empty Set.</p>
 
-     <div id="setname1.integers.ex1" class="mathml-example">
+     <div id="set-constants.ex1" class="mathml-example">
       <p>Content MathML</p>
 
       <div class="example mathml mml4c">
+	<pre>
+         &lt;apply&gt;&lt;in/&gt;&lt;cn type="integer"&gt;42&lt;/cn&gt;&lt;integers/&gt;&lt;/apply&gt;
+       </pre>
+      </div>
+      <div class="example mathml mml4c">
        <pre>
-         &lt;apply&gt;&lt;in/&gt;
-           &lt;cn type="integer"&gt; 42 &lt;/cn&gt;
-           &lt;integers/&gt;
-         &lt;/apply&gt;
+         &lt;apply&gt;&lt;in/&gt;&lt;cn type="real"&gt;44.997&lt;/cn&gt;&lt;reals/&gt;&lt;/apply&gt;
+       </pre>
+      </div>
+      <div class="example mathml mml4c">
+       <pre>
+         &lt;apply&gt;&lt;in/&gt;&lt;cn type="rational"&gt;22&lt;sep/&gt;7&lt;/cn&gt;&lt;rationals/&gt;&lt;/apply&gt;
+       </pre>
+      </div>
+      <div class="example mathml mml4c">
+       <pre>
+         &lt;apply&gt;&lt;in/&gt;&lt;cn type="integer"&gt;1729&lt;/cn&gt;&lt;naturalnumbers/&gt;&lt;/apply&gt;
+       </pre>
+      </div>
+      <div class="example mathml mml4c">
+       <pre>
+         &lt;apply&gt;&lt;in/&gt;&lt;cn type="complex-cartesian"&gt;17&lt;sep/&gt;29&lt;/cn&gt;&lt;complexes/&gt;&lt;/apply&gt;
+       </pre>
+      </div>
+      <div class="example mathml mml4c">
+       <pre>
+         &lt;apply&gt;&lt;in/&gt;&lt;cn type="integer"&gt;17&lt;/cn&gt;&lt;primes/&gt;&lt;/apply&gt;
+       </pre>
+      </div>
+      <div class="example mathml mml4c">
+       <pre>
+         &lt;apply&gt;&lt;neq/&gt;&lt;integers/&gt;&lt;emptyset/&gt;&lt;/apply&gt;
        </pre>
       </div>
 
@@ -7727,28 +7756,6 @@ infinity (&#x221e;).</p>
          &lt;mrow&gt;&lt;mn&gt;42&lt;/mn&gt;&lt;mo&gt;&amp;#x2208;&lt;/mo&gt;&lt;mi mathvariant="double-struck"&gt;Z&lt;/mi&gt;&lt;/mrow&gt;
        </pre>
       </div>
-
-      <blockquote>
-       <p><img src="image/setname1-integers-ex1.gif" alt="{{42}\unicode{8712}{\midoublestruck{Z}}}"></img></p>
-      </blockquote>
-     </div>
-
-          <p>This element represents the set of real numbers.</p>
-
-     <div id="setname1.reals.ex1" class="mathml-example">
-      <p>Content MathML</p>
-
-      <div class="example mathml mml4c">
-       <pre>
-         &lt;apply&gt;&lt;in/&gt;
-           &lt;cn type="real"&gt; 44.997&lt;/cn&gt;
-           &lt;reals/&gt;
-         &lt;/apply&gt;
-       </pre>
-      </div>
-
-      <p>Sample Presentation</p>
-
       <div class="example mathml mmlcore">
        <pre>
          &lt;mrow&gt;
@@ -7756,29 +7763,6 @@ infinity (&#x221e;).</p>
          &lt;/mrow&gt;
        </pre>
       </div>
-
-      <blockquote>
-       <p><img src="image/setname1-reals-ex1.gif" alt="{{44.997}\unicode{8712}{\midoublestruck{R}}}"></img></p>
-      </blockquote>
-     </div>
-
-     
-     <p>This element represents the set of rational numbers.</p>
-
-     <div id="setname1.rationals.ex1" class="mathml-example">
-      <p>Content MathML</p>
-
-      <div class="example mathml mml4c">
-       <pre>
-         &lt;apply&gt;&lt;in/&gt;
-           &lt;cn type="rational"&gt; 22 &lt;sep/&gt;7&lt;/cn&gt;
-           &lt;rationals/&gt;
-         &lt;/apply&gt;
-       </pre>
-      </div>
-
-      <p>Sample Presentation</p>
-
       <div class="example mathml mmlcore">
        <pre>
          &lt;mrow&gt;
@@ -7788,28 +7772,6 @@ infinity (&#x221e;).</p>
          &lt;/mrow&gt;
        </pre>
       </div>
-
-      <blockquote>
-       <p><img src="image/setname1-rationals-ex1.gif" alt="{{{22}/{7}}\unicode{8712}{\midoublestruck{Q}}}"></img></p>
-      </blockquote>
-     </div>
-
-          <p>This element represents the set of natural numbers (including zero).</p>
-
-     <div id="setname1.naturalnumbers.ex1" class="mathml-example">
-      <p>Content MathML</p>
-
-      <div class="example mathml mml4c">
-       <pre>
-         &lt;apply&gt;&lt;in/&gt;
-           &lt;cn type="integer"&gt;1729&lt;/cn&gt;
-           &lt;naturalnumbers/&gt;
-         &lt;/apply&gt;
-       </pre>
-      </div>
-
-      <p>Sample Presentation</p>
-
       <div class="example mathml mmlcore">
        <pre>
          &lt;mrow&gt;
@@ -7817,28 +7779,6 @@ infinity (&#x221e;).</p>
          &lt;/mrow&gt;
        </pre>
       </div>
-
-      <blockquote>
-       <p><img src="image/setname1-naturalnumbers-ex1.gif" alt="{{1729}\unicode{8712}{\midoublestruck{N}}}"></img></p>
-      </blockquote>
-     </div>
-
-          <p>This element represents the set of complex numbers.</p>
-
-     <div id="setname1.complexes.ex1" class="mathml-example">
-      <p>Content MathML</p>
-
-      <div class="example mathml mml4c">
-       <pre>
-         &lt;apply&gt;&lt;in/&gt;
-           &lt;cn type="complex-cartesian"&gt;17&lt;sep/&gt;29&lt;/cn&gt;
-           &lt;complexes/&gt;
-         &lt;/apply&gt;
-       </pre>
-      </div>
-
-      <p>Sample Presentation</p>
-
       <div class="example mathml mmlcore">
        <pre>
          &lt;mrow&gt;
@@ -7848,57 +7788,11 @@ infinity (&#x221e;).</p>
          &lt;/mrow&gt;
        </pre>
       </div>
-
-      <blockquote>
-       <p><img src="image/setname1-complexes-ex1.gif" alt="{{{17}+{29}\unicode{8290}i}\unicode{8712}{\midoublestruck{C}}}"></img></p>
-      </blockquote>
-     </div>
-
-          <p>This element represents the set of positive prime numbers.</p>
-
-     <div id="setname1.primes.ex1" class="mathml-example">
-      <p>Content MathML</p>
-
-      <div class="example mathml mml4c">
-       <pre>
-         &lt;apply&gt;&lt;in/&gt;
-           &lt;cn type="integer"&gt;17&lt;/cn&gt;
-           &lt;primes/&gt;
-         &lt;/apply&gt;
-       </pre>
-      </div>
-
-      <p>Sample Presentation</p>
-
       <div class="example mathml mmlcore">
        <pre>
          &lt;mrow&gt;&lt;mn&gt;17&lt;/mn&gt;&lt;mo&gt;&amp;#x2208;&lt;/mo&gt;&lt;mi mathvariant="double-struck"&gt;P&lt;/mi&gt;&lt;/mrow&gt;
        </pre>
       </div>
-
-      <blockquote>
-       <p><img src="image/setname1-primes-ex1.gif" alt="{{17}\unicode{8712}{\midoublestruck{P}}}"></img></p>
-      </blockquote>
-     </div>
-
-     
-     <p>This element is used to represent the empty set, that is the set which contains no
-     members.</p>
-
-     <div id="set1.emptyset.ex1" class="mathml-example">
-      <p>Content MathML</p>
-
-      <div class="example mathml mml4c">
-       <pre>
-         &lt;apply&gt;&lt;neq/&gt;
-           &lt;integers/&gt;
-           &lt;emptyset/&gt;
-         &lt;/apply&gt;
-       </pre>
-      </div>
-
-      <p>Sample Presentation</p>
-
       <div class="example mathml mmlcore">
        <pre>
          &lt;mrow&gt;
@@ -7907,12 +7801,32 @@ infinity (&#x221e;).</p>
        </pre>
       </div>
 
+<!--
+      <blockquote>
+       <p><img src="image/setname1-integers-ex1.gif" alt="{{42}\unicode{8712}{\midoublestruck{Z}}}"></img></p>
+      </blockquote>
+      <blockquote>
+       <p><img src="image/setname1-reals-ex1.gif" alt="{{44.997}\unicode{8712}{\midoublestruck{R}}}"></img></p>
+      </blockquote>
+      <blockquote>
+       <p><img src="image/setname1-rationals-ex1.gif" alt="{{{22}/{7}}\unicode{8712}{\midoublestruck{Q}}}"></img></p>
+      </blockquote>
+      <blockquote>
+       <p><img src="image/setname1-naturalnumbers-ex1.gif" alt="{{1729}\unicode{8712}{\midoublestruck{N}}}"></img></p>
+      </blockquote>
+      <blockquote>
+       <p><img src="image/setname1-complexes-ex1.gif" alt="{{{17}+{29}\unicode{8290}i}\unicode{8712}{\midoublestruck{C}}}"></img></p>
+      </blockquote>
+      <blockquote>
+       <p><img src="image/setname1-primes-ex1.gif" alt="{{17}\unicode{8712}{\midoublestruck{P}}}"></img></p>
+      </blockquote>
       <blockquote>
        <p><img src="image/set1-emptyset-ex1.gif" alt="{{\midoublestruck{Z}}\unicode{8800}\unicode{8709}}"></img></p>
       </blockquote>
+-->
+
+
      </div>
-
-
     </section>
 </section>
   


### PR DESCRIPTION
Combine descriptive paragraphs for each element into one.

Move all content and sample presentation examples under single heading for each type (so all can be folded togther)

Un-indented the small content examples so they become one line each

commented out the images (which have display:none anyway)