### PR TITLE
Merge elementary function descriptions

### DIFF
--- a/index.html
+++ b/index.html
@@ -160,6 +160,15 @@
                "href":     "https://openmath.org/standard/om20-2019-07-01/omstd20.html"
               },
 
+      "DLMF": {"title": "NIST Digital Library of Mathematical Functions, Release 1.1.5",
+               "href":  "http://dlmf.nist.gov/",
+               "date": "2022-03-15",
+	       "authors": ["F. W. J. Olver", "A. B. Olde Daalhuis",
+		  "D. W. Lozier", "B. I. Schneider", "R. F. Boisvert",
+		  "C. W. Clark", "B. R. Miller", "B. V. Saunders",
+	          "H. S. Cohl", "M. A. McClain"]
+	      },
+
   "Cajori1928":     {"title": "Cajori1928"},
   "MathMLforCSS":   {"title": "MathMLforCSS"},
   "Chaundy1954":    {"title": "Chaundy1954"},

--- a/src/contm-new.html
+++ b/src/contm-new.html
@@ -6340,7 +6340,7 @@
      <p>
       Differing definitions are in use for the inverse functions,
       so for maximum interoperability applications evaluating
-     such expressions should follow the definitions in [[DLMF]], <a href="https://dlmf.nist.gov/4">Chapter 4:Elementary Functions</a>.</p>
+     such expressions should follow the definitions in [[DLMF]], <a href="https://dlmf.nist.gov/4">Chapter 4: Elementary Functions</a>.</p>
      
      <div id="transc1.elementary.ex1" class="mathml-example">
       <p>Content MathML</p>

--- a/src/contm-new.html
+++ b/src/contm-new.html
@@ -6333,12 +6333,16 @@
      </p>
 
 
-     <p>These operator elements denote the standard trigonometric functions.  Since their
+     <p>These operator elements denote the standard trigonometric and hyperbolic functions and their inverses.  Since their
      standard
      interpretations are widely known, they are discussed as a group.
      </p>
-
-     <div id="transc1.sin.ex1" class="mathml-example">
+     <p>
+      Differing definitions are in use for the inverse functions,
+      so for maximum interoperability applications evaluating
+     such expressions should follow the definitions in [[Abramowitz1977]].</p>
+     
+     <div id="transc1.elementary.ex1" class="mathml-example">
       <p>Content MathML</p>
 
       <div class="example mathml mml4c">
@@ -6346,23 +6350,6 @@
          &lt;apply&gt;&lt;sin/&gt;&lt;ci&gt;x&lt;/ci&gt;&lt;/apply&gt;
        </pre>
       </div>
-
-      <p>Sample Presentation</p>
-
-      <div class="example mathml mmlcore">
-       <pre>
-         &lt;mrow&gt;&lt;mi&gt;sin&lt;/mi&gt;&lt;mo&gt;&amp;#x2061;&lt;/mo&gt;&lt;mi&gt;x&lt;/mi&gt;&lt;/mrow&gt;
-       </pre>
-      </div>
-
-      <blockquote>
-       <p><img src="image/transc1-sin-ex1.gif" alt="{\mathop{{\minormal{sin}}}x}"></img></p>
-      </blockquote>
-     </div>
-
-     <div id="transc1.sin.ex2" class="mathml-example">
-      <p>Content MathML</p>
-
       <div class="example mathml mml4c">
        <pre>
          &lt;apply&gt;&lt;sin/&gt;
@@ -6373,9 +6360,29 @@
          &lt;/apply&gt;
        </pre>
       </div>
+      <div class="example mathml mml4c">
+       <pre>
+         &lt;apply&gt;&lt;arcsin/&gt;&lt;ci&gt;x&lt;/ci&gt;&lt;/apply&gt;
+       </pre>
+      </div>
+      <div class="example mathml mml4c">
+       <pre>
+         &lt;apply&gt;&lt;sinh/&gt;&lt;ci&gt;x&lt;/ci&gt;&lt;/apply&gt;
+       </pre>
+      </div>
+      <div class="example mathml mml4c">
+       <pre>
+         &lt;apply&gt;&lt;arcsinh/&gt;&lt;ci&gt;x&lt;/ci&gt;&lt;/apply&gt;
+       </pre>
+      </div>
 
       <p>Sample Presentation</p>
 
+      <div class="example mathml mmlcore">
+       <pre>
+         &lt;mrow&gt;&lt;mi&gt;sin&lt;/mi&gt;&lt;mo&gt;&amp;#x2061;&lt;/mo&gt;&lt;mi&gt;x&lt;/mi&gt;&lt;/mrow&gt;
+       </pre>
+      </div>
       <div class="example mathml mmlcore">
        <pre>
          &lt;mrow&gt;
@@ -6391,27 +6398,6 @@
          &lt;/mrow&gt;
        </pre>
       </div>
-
-      <blockquote>
-       <p><img src="image/transc1-sin-ex2.gif" alt="{\mathop{{\minormal{sin}}}{\left.\middle({\mathop{{\minormal{cos}}}x}+\msup{x}{{3}}\middle)\right.}}"></img></p>
-      </blockquote>
-     </div>
-
-          <p>These operator elements denote the inverses of standard trigonometric functions.
-     Differing definitions are in use so for maximum interoperability applications evaluating
-     such expressions should follow the definitions in [[Abramowitz1977]].</p>
-
-     <div id="transc1.arcsin.ex1" class="mathml-example">
-      <p>Content MathML</p>
-
-      <div class="example mathml mml4c">
-       <pre>
-         &lt;apply&gt;&lt;arcsin/&gt;&lt;ci&gt;x&lt;/ci&gt;&lt;/apply&gt;
-       </pre>
-      </div>
-
-      <p>Sample Presentations</p>
-
       <div class="example mathml mmlcore">
        <pre>
          &lt;mrow&gt;
@@ -6419,15 +6405,7 @@
            &lt;mo&gt;&amp;#x2061;&lt;/mo&gt;
            &lt;mi&gt;x&lt;/mi&gt;
          &lt;/mrow&gt;
-       </pre>
-      </div>
-
-      <blockquote>
-       <p><img src="image/transc1-arcsin-ex1.gif" alt="{\mathop{{\minormal{arcsin}}}x}"></img></p>
-      </blockquote>
-
-      <div class="example mathml mml4c">
-       <pre>
+         &lt;text&gt;&amp;nbsp;&amp;nbsp;or&amp;nbsp;&amp;nbsp;&lt;/text&gt;
          &lt;mrow&gt;
            &lt;msup&gt;&lt;mi&gt;sin&lt;/mi&gt;&lt;mrow&gt;&lt;mo&gt;-&lt;/mo&gt;&lt;mn&gt;1&lt;/mn&gt;&lt;/mrow&gt;&lt;/msup&gt;
            &lt;mo&gt;&amp;#x2061;&lt;/mo&gt;
@@ -6435,49 +6413,11 @@
          &lt;/mrow&gt;
        </pre>
       </div>
-
-      <blockquote>
-       <p><img src="image/transc1-arcsin-ex2.gif" alt="{\mathop{{\minormal{sin}}^{-1}}x}"></img></p>
-      </blockquote>
-     </div>
-
-      <p>These operator elements denote the standard hyperbolic functions.
-     Since their standard interpretations are widely known, they are discussed as a group.</p>
-
-     <div id="transc1.sinh.ex1" class="mathml-example">
-      <p>Content MathML</p>
-
-      <div class="example mathml mml4c">
-       <pre>
-         &lt;apply&gt;&lt;sinh/&gt;&lt;ci&gt;x&lt;/ci&gt;&lt;/apply&gt;
-       </pre>
-      </div>
-
-      <p>Sample Presentation</p>
-
       <div class="example mathml mmlcore">
        <pre>
          &lt;mrow&gt;&lt;mi&gt;sinh&lt;/mi&gt;&lt;mo&gt;&amp;#x2061;&lt;/mo&gt;&lt;mi&gt;x&lt;/mi&gt;&lt;/mrow&gt;
        </pre>
       </div>
-
-     </div>
-
-          <p>These operator elements denote the inverses of standard hyperbolic functions.
-     Differing definitions are in use so for maximum interoperability applications evaluating
-     such expressions should follow the definitions in [[Abramowitz1977]].</p>
-
-     <div id="transc1.arcsinh.ex1" class="mathml-example">
-      <p>Content MathML</p>
-
-      <div class="example mathml mml4c">
-       <pre>
-         &lt;apply&gt;&lt;arcsinh/&gt;&lt;ci&gt;x&lt;/ci&gt;&lt;/apply&gt;
-       </pre>
-      </div>
-
-      <p>Sample Presentations</p>
-
       <div class="example mathml mmlcore">
        <pre>
          &lt;mrow&gt;
@@ -6485,11 +6425,7 @@
            &lt;mo&gt;&amp;#x2061;&lt;/mo&gt;
            &lt;mi&gt;x&lt;/mi&gt;
          &lt;/mrow&gt;
-       </pre>
-      </div>
-
-      <div class="example mathml mml4c">
-       <pre>
+         &lt;text&gt;&amp;nbsp;&amp;nbsp;or&amp;nbsp;&amp;nbsp;&lt;/text&gt;
          &lt;mrow&gt;
            &lt;msup&gt;&lt;mi&gt;sinh&lt;/mi&gt;&lt;mrow&gt;&lt;mo&gt;-&lt;/mo&gt;&lt;mn&gt;1&lt;/mn&gt;&lt;/mrow&gt;&lt;/msup&gt;
            &lt;mo&gt;&amp;#x2061;&lt;/mo&gt;
@@ -6499,6 +6435,36 @@
       </div>
 
      </div>
+<!--
+      <blockquote>
+       <p><img src="image/transc1-sin-ex1.gif" alt="{\mathop{{\minormal{sin}}}x}"></img></p>
+      </blockquote>
+ -->
+
+
+<!--
+      <blockquote>
+       <p><img src="image/transc1-sin-ex2.gif" alt="{\mathop{{\minormal{sin}}}{\left.\middle({\mathop{{\minormal{cos}}}x}+\msup{x}{{3}}\middle)\right.}}"></img></p>
+      </blockquote>
+      -->
+
+
+<!--
+      <blockquote>
+       <p><img src="image/transc1-arcsin-ex1.gif" alt="{\mathop{{\minormal{arcsin}}}x}"></img></p>
+      </blockquote>
+      -->
+      
+<!--
+      <blockquote>
+       <p><img src="image/transc1-arcsin-ex2.gif" alt="{\mathop{{\minormal{sin}}^{-1}}x}"></img></p>
+      </blockquote>
+      -->
+
+
+
+
+
 
 
     </section>

--- a/src/contm-new.html
+++ b/src/contm-new.html
@@ -6340,7 +6340,7 @@
      <p>
       Differing definitions are in use for the inverse functions,
       so for maximum interoperability applications evaluating
-     such expressions should follow the definitions in [[Abramowitz1977]].</p>
+     such expressions should follow the definitions in [[DLMF]], <a href="https://dlmf.nist.gov/4">Chapter 4:Elementary Functions</a>.</p>
      
      <div id="transc1.elementary.ex1" class="mathml-example">
       <p>Content MathML</p>


### PR DESCRIPTION
Unify the duplicated paragraphs

place all content examples under a single heading

place all presentations under a single heading

merge arcsin and sin^{-1} presentations, so that there are same number of example blocks

comment out images (which would need to be regenerated if brought back)

@brucemiller I left in a reference to A&S but I'm temped to replace all such references by DLMF ?