### PR TITLE
Tabular

### DIFF
--- a/src/presentation-markup.html
+++ b/src/presentation-markup.html
@@ -2303,11 +2303,13 @@
         <td colspan="3" class="attdesc">
    Specifies an additional indentation offset relative to the position determined
    by <code class="attribute">indentalign</code>.
-   <span>When the value is a percentage value or number without unit,
+   When the value is a percentage value,
    the value is relative to the
    horizontal space that a MathML renderer has available, this is the current target
    width as used for
-   linebreaking as specified in <a href="#presm_linebreaking"></a></span>
+   linebreaking as specified in <a href="#presm_linebreaking"></a>.
+   Note: numbers without units were allowed in MathML 3 and treated similarly to percentage values,
+   but unitless numbers are deprecated in MathML 4.
         </td>
        </tr>
  
@@ -6708,17 +6710,18 @@
       <tr>
        <td colspan="3" class="attdesc">
         specifies the desired width of the entire table and is intended for visual user agents.
-        <span>When the value is a percentage value or number without unit,
+        When the value is a percentage value,
         the value is relative to the
-        horizontal space that a MathML renderer has available
- 
-        <span>, this is the current target width as used for
-        linebreaking as specified in <a href="#presm_linebreaking"></a></span>;
+        horizontal space that a MathML renderer has available,
+        this is the current target width as used for
+        linebreaking as specified in <a href="#presm_linebreaking"></a>;
         this allows the author to specify, for example, a table being full width
-        of the display.</span>
+        of the display.
         When the value is <code class="attributevalue">auto</code>, the MathML
         renderer should calculate the table width from its contents using
         whatever layout algorithm it chooses.
+        Note: numbers without units were allowed in MathML 3 and treated similarly to percentage values,
+        but unitless numbers are deprecated in MathML 4.     
        </td>
       </tr>
  
@@ -6948,11 +6951,6 @@
      </pre>
     </div>
  
-    <p>This might be rendered as:
-    </p>
-    <blockquote>
-     <p><img src="image/f3025.gif" alt="\left(\begin{array}{ccc}1 &amp; 0 &amp; 0 \\ 0 &amp; 1 &amp; 0 \\ 0 &amp; 0 &amp; 1\end{array}\right)"></img></p>
-    </blockquote>
     <p>
      Note that the parentheses must be represented explicitly; they are not
      part of the <code class="element">mtable</code> element's rendering. This allows
@@ -7154,7 +7152,7 @@
    <section class="fold">
     <h5>Example</h5>
  
-    <div class="example mathml mmlcore">
+    <div class="example mathml mml4p">
      <pre>
        &lt;mtable&gt;
          &lt;mlabeledtr id='e-is-m-c-square'&gt;
@@ -7179,21 +7177,7 @@
        &lt;/mtable&gt;
      </pre>
     </div>
- 
-    <p>This should be rendered as:</p>
- 
-    <table>
- 
-     <tbody>
- 
-      <tr>
-       <td id="eqnoc1">&#xa0;&#xa0;&#xa0;&#xa0;&#xa0;</td>
-       <td id="eqnoc2"><i class="var">E</i> = <i class="var">m</i><i class="var">c</i><sup>2</sup></td>
-       <td id="eqnoc3">(2.1)</td>
-      </tr>
-     </tbody>
-    </table>
- 
+  
    </section>
   </section>
  
@@ -7244,7 +7228,7 @@
        <td colspan="3" class="attdesc">
         causes the cell to be treated as if it occupied the number of rows specified.
         The corresponding <code class="element">mtd</code> in the following <code class="attributevalue">rowspan</code>-1 rows must be omitted.
-        The interpretation corresponds with the similar attributes for HTML 4.01 tables.
+        The interpretation corresponds with the similar attributes for HTML tables.
        </td>
       </tr>
  
@@ -7259,7 +7243,7 @@
        <td colspan="3" class="attdesc">
         causes the cell to be treated as if it occupied the number of columns specified.
         The following <code class="attributevalue">rowspan</code>-1 <code class="element">mtd</code>s must be omitted.
-        The interpretation corresponds with the similar attributes for HTML 4.01 tables.
+        The interpretation corresponds with the similar attributes for HTML tables.
        </td>
       </tr>
  
@@ -7949,16 +7933,7 @@
  <h5>MathML representation of an alignment example</h5>
  
  <p>The above rules are sufficient to explain the MathML representation
- of the example given near the start of this section.
- To repeat the example, the desired rendering is:</p>
- 
- <div class="example ">
-  <pre>
-   8.44x + 55  y =  0
-   3.1 x -  0.7y = -1.1
- </pre>
- </div>
- 
+ of the example given near the start of <a href="#presm_malign">this section</a>.
  
  <p>One way to represent that in MathML is:</p>
  

--- a/src/presentation-markup.html
+++ b/src/presentation-markup.html
@@ -7322,7 +7322,8 @@
     inserting spacing somewhat like that shown here:</p>
  
     <div class="example ">
-      <table style="font-family:math">
+     <table style="font-family:math">
+      <tbody>
         <tr>
           <td>8.44<em>x</em></td>
           <td style="padding-left:.22em; padding-right: .22em;">+</td>
@@ -7337,27 +7338,30 @@
           <td style="padding-left:.28em; padding-right: .28em;">=</td>
           <td>&#x2212;1.1</td>
         </tr>
-      </table>
+      </tbody>
+     </table>
     </div>
     <p>If the example expressions shown above were arranged in a column
     but not aligned, they would appear as:</p>
  
     <div class="example ">
-      <table style="font-family:math">
+     <table style="font-family:math">
+      <tbody>
         <tr>
           <td>8.44<em>x</em></td>
           <td style="padding-left:.22em; padding-right: .22em;">+</td>
-          <td>55.7</span><em>y</em></td>
+          <td>55.7<em>y</em></td>
           <td style="padding-left:.28em; padding-right: .28em;">=</td>
           <td><span style="visibility: hidden">&#x2212;</span>0</td>
         </tr>
         <tr>
           <td>3.1<span style="visibility: hidden">4</span><em>x</em></td>
           <td style="padding-left:.22em; padding-right: .22em;">&#x2212;</td>
-          <td>5</span>0.7<em>y</em></td>
+          <td>50.7<em>y</em></td>
           <td style="padding-left:.28em; padding-right: .28em;">=</td>
           <td>&#x2212;1.1</td>
-        </tr>
+         </tr>
+      </tbody>
       </table>
     </div>
     <p>For audio renderers, it is suggested that the alignment elements
@@ -7555,7 +7559,8 @@
     produce:</p>
  
     <div class="example ">
-     <table style="font-family:math;">
+    <table style="font-family:math;">
+      <tbody>
       <tr><td colspan="5">equations with aligned variables</td></tr>
       <tr>
         <td>8.44<em>x</em></td>
@@ -7571,13 +7576,14 @@
         <td style="padding-left:.28em; padding-right: .28em;">=</td>
         <td>&#x2212;1.1</td>
       </tr>
+      </tbody>
     </table>
-
     </div>
-    or, with a shorter heading,
+    <p>or, with a shorter heading,</p>
  
     <div class="example ">
-      <table style="font-family:math">
+     <table style="font-family:math">
+      <tbody>
         <tr><td colspan="5">some equations</td></tr>
         <tr>
           <td>8.44<em>x</em></td>
@@ -7593,8 +7599,9 @@
           <td style="padding-left:.28em; padding-right: .28em;">=</td>
           <td>&#x2212;1.1</td>
         </tr>
-      </table>
-   
+      </tbody>
+     </table>
+    </div>
    </section>
  
    <section>

--- a/src/presentation-markup.html
+++ b/src/presentation-markup.html
@@ -7933,7 +7933,7 @@
  <h5>MathML representation of an alignment example</h5>
  
  <p>The above rules are sufficient to explain the MathML representation
- of the example given near the start of <a href="#presm_malign">this section</a>.
+ of the example given near the start of <a href="#presm_malign">this section</a>.</p>
  
  <p>One way to represent that in MathML is:</p>
  

--- a/src/presentation-markup.html
+++ b/src/presentation-markup.html
@@ -7579,6 +7579,33 @@
       </tbody>
     </table>
     </div>
+
+    <div class="example ">
+    <table style="font-family:math;">
+      <tbody>
+      <tr><td colspan="7">equations with aligned variables</td></tr>
+      <tr>
+	<td>&#160;&#160;&#160;&#160;&#160;</td>
+        <td>8.44<em>x</em></td>
+        <td style="padding-left:.22em; padding-right: .22em;">+</td>
+        <td>55<span style="visibility: hidden">.7</span><em>y</em></td>
+        <td style="padding-left:.28em; padding-right: .28;">=</td>
+        <td><span style="visibility: hidden">-</span>0</td>
+	<td>&#160;&#160;&#160;&#160;&#160;</td>
+      </tr>
+      <tr>
+	<td></td>
+        <td>3.1<span style="visibility: hidden">4</span><em>x</em></td>
+        <td style="padding-left:.22em; padding-right: .22em;">&#x2212;</td>
+        <td><span style="visibility: hidden">5</span>0.7<em>y</em></td>
+        <td style="padding-left:.28em; padding-right: .28em;">=</td>
+        <td>&#x2212;1.1</td>
+	<td></td>
+      </tr>
+      </tbody>
+    </table>
+    </div>
+    
     <p>or, with a shorter heading,</p>
  
     <div class="example ">

--- a/src/presentation-markup.html
+++ b/src/presentation-markup.html
@@ -7561,28 +7561,6 @@
     <div class="example ">
     <table style="font-family:math;">
       <tbody>
-      <tr><td colspan="5">equations with aligned variables</td></tr>
-      <tr>
-        <td>8.44<em>x</em></td>
-        <td style="padding-left:.22em; padding-right: .22em;">+</td>
-        <td>55<span style="visibility: hidden">.7</span><em>y</em></td>
-        <td style="padding-left:.28em; padding-right: .28;">=</td>
-        <td><span style="visibility: hidden">-</span>0</td>
-      </tr>
-      <tr>
-        <td>3.1<span style="visibility: hidden">4</span><em>x</em></td>
-        <td style="padding-left:.22em; padding-right: .22em;">&#x2212;</td>
-        <td><span style="visibility: hidden">5</span>0.7<em>y</em></td>
-        <td style="padding-left:.28em; padding-right: .28em;">=</td>
-        <td>&#x2212;1.1</td>
-      </tr>
-      </tbody>
-    </table>
-    </div>
-
-    <div class="example ">
-    <table style="font-family:math;">
-      <tbody>
       <tr><td colspan="7">equations with aligned variables</td></tr>
       <tr>
 	<td>&#160;&#160;&#160;&#160;&#160;</td>
@@ -7611,7 +7589,7 @@
     <div class="example ">
      <table style="font-family:math">
       <tbody>
-        <tr><td colspan="5">some equations</td></tr>
+        <tr><td colspan="5" style="text-align: center;">some equations</td></tr>
         <tr>
           <td>8.44<em>x</em></td>
           <td style="padding-left:.22em; padding-right: .22em;">+</td>

--- a/src/presentation-markup.html
+++ b/src/presentation-markup.html
@@ -7987,8 +7987,7 @@
  
  <div class="example mathml mml4p">
   <pre>
-    &lt;mtable groupalign=
-   "{decimalpoint left left decimalpoint left left decimalpoint}"&gt;
+    &lt;mtable groupalign="{decimalpoint left left decimalpoint left left decimalpoint}"&gt;
       &lt;mtr&gt;
         &lt;mtd&gt;
           &lt;mrow&gt;

--- a/src/presentation-markup.html
+++ b/src/presentation-markup.html
@@ -7322,19 +7322,43 @@
     inserting spacing somewhat like that shown here:</p>
  
     <div class="example ">
-     <pre>
-      8.44x + 55  y =  0
-      3.1 x -  0.7y = -1.1
-     </pre>
+      <table style="font-family:math">
+        <tr>
+          <td>8.44<em>x</em></td>
+          <td style="padding-left:.22em; padding-right: .22em;">+</td>
+          <td>55<span style="visibility: hidden">.7</span><em>y</em></td>
+          <td style="padding-left:.28em; padding-right: .28;">=</td>
+          <td><span style="visibility: hidden">-</span>0</td>
+        </tr>
+        <tr>
+          <td>3.1<span style="visibility: hidden">4</span><em>x</em></td>
+          <td style="padding-left:.22em; padding-right: .22em;">&#x2212;</td>
+          <td><span style="visibility: hidden">5</span>0.7<em>y</em></td>
+          <td style="padding-left:.28em; padding-right: .28em;">=</td>
+          <td>&#x2212;1.1</td>
+        </tr>
+      </table>
     </div>
     <p>If the example expressions shown above were arranged in a column
     but not aligned, they would appear as:</p>
  
     <div class="example ">
-     <pre>
-      8.44x + 55y = 0
-      3.1x - 0.7y = -1.1
-     </pre>
+      <table style="font-family:math">
+        <tr>
+          <td>8.44<em>x</em></td>
+          <td style="padding-left:.22em; padding-right: .22em;">+</td>
+          <td>55.7</span><em>y</em></td>
+          <td style="padding-left:.28em; padding-right: .28em;">=</td>
+          <td><span style="visibility: hidden">&#x2212;</span>0</td>
+        </tr>
+        <tr>
+          <td>3.1<span style="visibility: hidden">4</span><em>x</em></td>
+          <td style="padding-left:.22em; padding-right: .22em;">&#x2212;</td>
+          <td>5</span>0.7<em>y</em></td>
+          <td style="padding-left:.28em; padding-right: .28em;">=</td>
+          <td>&#x2212;1.1</td>
+        </tr>
+      </table>
     </div>
     <p>For audio renderers, it is suggested that the alignment elements
     produce the analogous behavior of altering the rhythm of pronunciation
@@ -7531,22 +7555,46 @@
     produce:</p>
  
     <div class="example ">
-     <pre>
-      equations with aligned variables
-      8.44x + 55  y =  0
-      3.1 x -  0.7y = -1.1
-     </pre>
+     <table style="font-family:math;">
+      <tr><td colspan="5">equations with aligned variables</td></tr>
+      <tr>
+        <td>8.44<em>x</em></td>
+        <td style="padding-left:.22em; padding-right: .22em;">+</td>
+        <td>55<span style="visibility: hidden">.7</span><em>y</em></td>
+        <td style="padding-left:.28em; padding-right: .28;">=</td>
+        <td><span style="visibility: hidden">-</span>0</td>
+      </tr>
+      <tr>
+        <td>3.1<span style="visibility: hidden">4</span><em>x</em></td>
+        <td style="padding-left:.22em; padding-right: .22em;">&#x2212;</td>
+        <td><span style="visibility: hidden">5</span>0.7<em>y</em></td>
+        <td style="padding-left:.28em; padding-right: .28em;">=</td>
+        <td>&#x2212;1.1</td>
+      </tr>
+    </table>
+
     </div>
     or, with a shorter heading,
  
     <div class="example ">
-     <pre>
-      some equations
-      8.44x + 55  y =  0
-      3.1 x -  0.7y = -1.1
-     </pre>
-    </div>
- 
+      <table style="font-family:math">
+        <tr><td colspan="5">some equations</td></tr>
+        <tr>
+          <td>8.44<em>x</em></td>
+          <td style="padding-left:.22em; padding-right: .22em;">+</td>
+          <td>55<span style="visibility: hidden">.7</span><em>y</em></td>
+          <td style="padding-left:.28em; padding-right: .28;">=</td>
+          <td><span style="visibility: hidden">-</span>0</td>
+        </tr>
+        <tr>
+          <td>3.1<span style="visibility: hidden">4</span><em>x</em></td>
+          <td style="padding-left:.22em; padding-right: .22em;">&#x2212;</td>
+          <td><span style="visibility: hidden">5</span>0.7<em>y</em></td>
+          <td style="padding-left:.28em; padding-right: .28em;">=</td>
+          <td>&#x2212;1.1</td>
+        </tr>
+      </table>
+   
    </section>
  
    <section>


### PR DESCRIPTION
Change the examples in the alto use fake MathML with tables as suggested by @davidcarlisle in https://github.com/w3c/mathml/issues/354

The first example in #table-cells-that-are-not-divided-into-alignment-groups is not right though. The long first cell is spacing out the rest of the cells. I played with `table-layout` but didn't see a solution there. Maybe something with width and overflow might work. @davidcarlisle: do you know how to get this right?