### PR TITLE
Davidc/intent

### DIFF
--- a/src/mixing.html
+++ b/src/mixing.html
@@ -26,9 +26,9 @@
 
  <section>
   <h3 id="mixing_intent">The <code class="attribute">intent</code> attribute</h3>
-  <p>As decribed in <a href="#presm"></a> presentation <span class="ednote">Content? See <a href="https://github.com/w3c/mathml/issues/289">Issue 289</a>.</span>
+  <p>As decribed in <a href="#presm_presatt_intent"></a>, Presentation
   MathML elements
-  (including [[MathML-Core]] allow attributes <code
+  allow attributes <code
   class="attribute">intent</code> and <code
   class="attribute">arg</code> that as described here allow the
   <dfn><q>intent</q></dfn> of the term to be specified. This
@@ -44,9 +44,7 @@
   <code>intent="power($base,$exponent)"</code>. The parts consist
   of:</p>
   <ul>
-  <li><em>references</em> prefixed with <code>$</code>. A numeric
-  reference such as <code>$3/$1</code> references the [=intent=] of
-  the first child of the 3rd child of the element. An argument
+  <li><em>references</em> prefixed with <code>$</code>. An argument
   reference such as <code>$name</code> references a descendent element
   that has an attribute <code>arg="name"</code>. Unlike <code class="attribute">id</code>
   attributes, <code class="attribute">arg</code> do not have to be
@@ -55,7 +53,7 @@
   elements that have a set <code class="attribute">intent</code> or
   <code class="attribute">arg</code> attribute, without descending into them.</li>
   <li><em>literal numbers</em> such as <code>2.5</code> denote
-  themselves. <span class="ednote">0.25e1?</span></li>
+  themselves.</li>
   <li><em>literal identifiers</em> Non numeric literals reference
   terms in the intent dictionary, currently located at <a
   href="https://docs.google.com/spreadsheets/d/1EsWou1K5nxBdLPvQapdoA9h-s8lg_qjn8fJH64g9izQ/edit#gid=1358098730">Google
@@ -66,13 +64,6 @@
   be generated. Terms in other levels may be contributed; the
   dictionary may give speech hints, but a system may also fall back on
   reading the identifier name as given.</li>
-  <li><em>the wildcard</em>, <code>*</code> denotes all the child
-  elements that are not an [=embellished operator=].
-  So
-  that <code>intent="somefunction(*)"</code> is equivalent to
-  <code>intent="somefunction($arg1,$arg2, ...)"</code> where
-  <code class="attribute">arg</code> attributes are added to all the
-  non-operator children.</li>
   </ul>
 
 <p>The key component here is the literal. A literal is intended to
@@ -90,25 +81,7 @@ the user and agent.</p>
   <section>
    <h4 id="mixing_intent_grammar">The Grammar for <code class="attribue">intent</code></h4>
 
-   <div class="ednote">
-     <p>These grammar distill various suggestions but the Working Group has not yet agreed a final version.</p>
-
-     <p>The basic idea of a functional syntax and argref are likely to stay but details around
-     paths and wildcards and exact characters allowed in identifiers all subject to discussion.</p>
-
-     <p>See <a href="https://github.com/w3c/mathml/issues/252">Issue 252</a></p>
-   </div>
-   <pre>
-intent   := literal | selector | intent '(' wildcard ')' | intent '(' intent [ ',' intent ]* ')'
-literal  := ( letters | digits | '.' | '_' | '-' )*
-selector := argref | numref
-argref   := '$' NCName
-numref   := '$' [digit]+ ( '/' numref )?
-wildcard := '*'
-   </pre>
-
-   <p>Alternative with no numeric paths or wildcards</p>
- <pre class="bnf">
+ <pre class="def bnf">
 intent   := number | NCName | argref | function
 function := (NCName | argref) '(' intent [ ',' intent ]* ')'
 number   := '-'? digit+ ('.' digit+)? 

--- a/src/presentation-markup.html
+++ b/src/presentation-markup.html
@@ -1002,11 +1002,74 @@
   </section>
  
   <section>
-   <h4 id="presm_presatt">Mathematics style attributes common to presentation elements</h4>
+   <h4 id="presm_presatt">Mathematics attributes common to presentation elements</h4>
  
    <p>In addition to the attributes listed in <a href="#fund_globatt"></a>,
-   all MathML presentation elements accept the following two attributes:</p>
+   all MathML presentation elements accept the following classes of atribute.</p>
+
+   
+  <section>
+   <h5 id="presm_presatt_intent">Intent Attributes</h5>
+   <div class="ednote">Depending on the outcome of <a
+   href="https://github.com/w3c/mathml/issues/289">Issue 289</a> this
+   description may move to chapter 2 Global Attributes.</div>
+   
+   <p>All MathML presentation elements accept <code
+   class="attribute">intent</code> and <code
+   class="attribute">arg</code> attributes to support specifying
+   <q>intent</q>. These are more fully described in
+   [[[#mixing_intent]]].</p>
+   <table class="attributes data">
  
+    <thead>
+ 
+     <tr>
+      <td>Name</td>
+      <td>values</td>
+      <td>default</td>
+      <td>Core</td>
+     </tr>
+    </thead>
+ 
+    <tbody>
+ 
+     <tr>
+      <td rowspan="2" class="attname">intent</td>
+      <td><a class="intref" href="#mixing_intent_grammar"><em>intent expresssion</em></a></td>
+      <td><em>none</em></td>
+      <td><a class="coreyes" href="./#parsing"></a></td>
+     </tr>
+    <tr>
+      <td colspan="3" class="attdesc">Inent...</td>
+    </tr>
+      <tr>
+      <td rowspan="2" class="attname">arg</td>
+      <td><a class="intref" href="#mixing_intent_grammar"><em>name</em></a></td>
+      <td><em>none</em></td>
+      <td><a class="coreyes" href="./#parsing"></a></td>
+     </tr>
+     <tr>
+      <td colspan="3" class="attdesc">Arg...</td>
+     </tr>
+    </tbody>
+      </table>
+
+  </section>
+
+   <section>
+   <h5 id="presm_presatt_core">MathML Core Attributes</h5>
+ 
+   <p>Presentation elements also accept all the <a
+   href="https://w3c.github.io/mathml-core/#global-attributes">Global
+   Attributes</a> specified by [[MathML-Core]].</p>
+ 
+   <p>These attributes include the following two attributes that are primarily intended for visual media.
+   They are not expected to affect the intended semantics of displayed
+   expressions, but are for use in highlighting or drawing attention
+   to the affected subexpressions.  For example, a red "x" is not assumed
+   to be semantically different than a black "x", in contrast to
+   variables with different <code class="attribute">mathvariant</code> values (See <a href="#presm_commatt"></a>).</p>
+
    <table class="attributes data">
  
     <thead>
@@ -1054,12 +1117,6 @@
     </tbody>
    </table>
  
-   <p>These style attributes are primarily intended for visual media.
-   They are not expected to affect the intended semantics of displayed
-   expressions, but are for use in highlighting or drawing attention
-   to the affected subexpressions.  For example, a red "x" is not assumed
-   to be semantically different than a black "x", in contrast to
-   variables with different <code class="attribute">mathvariant</code> values (See <a href="#presm_commatt"></a>).</p>
  
    <p>Since MathML expressions are often embedded in a textual data
    format such as <span>HTML</span>,
@@ -1082,7 +1139,7 @@
    region affected by the <code class="attribute">mathbackground</code> attribute is not
    defined by these rules.</p>
   </section>
- 
+  </section>
  </section>
  
  
@@ -2733,7 +2790,7 @@
      context. If it is not specified, and there is more than one possible
      form in the dictionary for an <code class="element">mo</code> element with
      given content, the renderer should choose which form to use as follows
-     (but see the exception for embellished operators, described later):
+     (but see the exception for [=embellished operators=], described later):
      </p>
      <ul>
  


### PR DESCRIPTION
Initial steps...

Adds new subsections to 3.1.9 adding MathML Core and intent attributes (following status quo of intent being Presentation only)

Start cleaning up chapter5, just show one version of the grammar, can now link to the earlier section introducing intent  so deleted the ednote querying whether that would be in chapter 3 for just presentation or chapter 2  for global.

Still needs more examples and more words.

