### PR TITLE
move fold to subsections

### DIFF
--- a/src/presentation-markup.html
+++ b/src/presentation-markup.html
@@ -9063,10 +9063,10 @@
  </section>
  </section>
  
- <section class="fold">
+ <section>
  <h4 id="presm_elemmath_examples">Elementary Math Examples</h4>
  
- <section>
+ <section class="fold">
  <h5 id="presm_addsub">Addition and Subtraction</h5>
  
  <p>Two-dimensional addition, subtraction, and multiplication typically
@@ -9203,7 +9203,7 @@
  
  </section>
  
- <section>
+ <section class="fold">
  <h5 id="presm_mult">Multiplication</h5>
  
  <p>Below is a simple multiplication example that illustrates the use of <code class="element">msgroup</code> and
@@ -9276,7 +9276,7 @@
  
  </section>
  
- <section>
+ <section class="fold">
  <h5 id="presm_mlongdiv_ex">Long Division</h5>
  
  <p>
@@ -9479,7 +9479,7 @@
  
  </section>
  
- <section>
+ <section class="fold">
  <h5 id="presm_repeatdec">Repeating decimal</h5>
  
  <p>


### PR DESCRIPTION
#322 points out the styling around folding sections isn't great, I can look at that again but a particularly bad  case is the elementary math examples. Here I'd like to avoid the issue by moving the fold to the subsections. Not only does that make all  adjacent sections folded, it  re-enables the links in the tables of contents, which don't work currently. Similarly I have over the years several times referenced the collection of long division examples but the fragid to that section doesn't really work if its parent is folded.

In the last PR you commented

> (a little hard to tell without seeing it)

Should be able to review locally any of these PR by going (in this case)

```
git checkout  davidc/elmentary-fold
git pull
```

Then viewing the local version, but I add a screenshot here




![image](https://user-images.githubusercontent.com/1268738/169664695-c2d6e3b8-9fab-4bf9-ae62-0afa2f8e34f4.png)
