### PR TITLE
Davidc/intent2

### DIFF
--- a/index.html
+++ b/index.html
@@ -87,7 +87,7 @@
 	    m.setAttribute("class",
 			   mclass.replace("example mathml","") +
 			   " inlinemath");
-	    m.innerHTML=mmllist[i].textContent;
+	    m.innerHTML=mmllist[i].querySelector("pre").textContent;
 	    var atext;
 	    var aattrib=mmllist[i].getAttribute("alttext");
 	    if (aattrib)  {

--- a/src/mixing.html
+++ b/src/mixing.html
@@ -81,58 +81,193 @@ the user and agent.</p>
   <section>
    <h4 id="mixing_intent_grammar">The Grammar for <code class="attribue">intent</code></h4>
 
- <pre class="def bnf">
+   <p>The <code class="attribute">intent</code>, after ignoring white
+   space between tokens, should match the following grammar.</p>
+   
+<pre class="def bnf">
 intent   := number | NCName | argref | function
 function := (NCName | argref) '(' intent [ ',' intent ]* ')'
 number   := '-'? digit+ ('.' digit+)? 
 argref   := '$' NCName
-   </pre>
+</pre>
 
+<p>Here <a href="https://www.w3.org/TR/REC-xml-names/#NT-NCName"><code>NCName</code></a>
+is as defined in  in [[xml-names]], and <code>digit</code> is a character in the range 0–9.</p>
   </section>
 
 
 
  <section>
-  <h3 id="mixing_intent_examplesn">Intent Examples</h3>
+  <h3 id="mixing_intent_examples">Intent Examples</h3>
 
-<p>With this model, the <code class="element">msup</code> examples:
-as a power;
-as a transpose;
-as a derivative; and
-as an embellished symbol would be distinguished as follows:</p>
+  
+ <section>
+  <h4 id="mixing_intent_examples_notation">Ambiguous Notation</h4>
 
-<pre class="xml nonumexample">
+  <p>A primary use for <code class="attribute">intent</code> is to
+  disambiguate cases where the same syntax is used for different meanings,
+  and typically has different readings.</p>
+  
+<p>Superscript, <code class="element">msup</code>, may represent a power, a transpose,
+a derivative or an embellished symbol. These cases would be distinguished as follows:</p>
+
+<div class="example mathml mmlcore">
+<pre>
 &lt;msup intent="power($base,$exp)">
   &lt;mi arg="base">x&lt;/mi>
   &lt;mi arg="exp">n&lt;/mi>
 &lt;/msup>
-</pre>
-
-<pre class="xml nonumexample">
+&lt;mo>&#x2192;&lt;/mo>
 &lt;msup intent="$op($a)">
   &lt;mi arg="a">A&lt;/mi>
   &lt;mi arg="op" intent="transpose">T&lt;/mi>
 &lt;/msup>
-</pre>
-
-<p>(easily adapted to conjugate and adjoint)</p>
-
-<pre class="xml nonumexample">
+&lt;mo>&#x2192;&lt;/mo>
 &lt;msup intent="derivative($a)">
   &lt;mi arg="a">f&lt;/mi>
-  &lt;mi>'&lt;/mi>
+  &lt;mi>&amp;prime;&lt;/mi>
 &lt;/msup>
-</pre>
-
-<pre class="xml nonumexample">
+&lt;mo>&#x2192;&lt;/mo>
 &lt;msup intent="x-prime">
   &lt;mi>x&lt;/mi>
-  &lt;mo>'&lt;/mo>
+  &lt;mo>&amp;prime;&lt;/mo>
 &lt;/msup>
 </pre>
+</div>
 
+<p>Similarly an over bar may represent complex conjugation, or mean (average):</p>
+
+<div class="example mathml mmlcore">
+<pre>
+&lt;mover intent="conjugate($v)"&gt;
+  &lt;mi arg="v"&gt;z&lt;/mi&gt;
+  &lt;mo&gt;&amp;#xaf;&lt;/mo&gt;
+&lt;/mover&gt;
+&lt;mtext>&amp;nbsp;is not&amp;nbsp;&lt;/mtext>
+&lt;mover intent="mean($var)"&gt;
+  &lt;mi arg="var"&gt;X&lt;/mi&gt;
+  &lt;mo&gt;&amp;#xaf;&lt;/mo&gt;
+&lt;/mover&gt;
+</pre>
+</div>
 
  </section>
+
+ <section>
+  <h4 id="mixing_intent_examples_advanced">Advanced or Non-Standard Notation</h4>
+
+  <p>A special case of ambiguous notation is the re-use of standard
+  notation with meaning that may be specific to a subject area or evn
+  individual document,</p>
+  
+<div class="example mathml mmlcore">
+<pre>
+&lt;msub intent="bell-number($index)"&gt;
+  &lt;mi&gt;B&lt;/mi&gt;
+  &lt;mn arg="index"&gt;2&lt;/m&gt;
+&lt;/msub&gt;
+</pre>
+</div>
+
+<p>Here the subscripted B denoting the <em>Bell Number</em> is annotated using
+<code>bell-number</code> intent which is not in the core <q>Level 1</q>
+dictionary but is in the open <q>Level 3</q> dictionary of more advanced or specialist
+topics.</p>
+ 
+ </section>
+
+ 
+ <section>
+  <h4 id="mixing_intent_examples_mtr">Tables</h4>
+<div class="issue"  data-number="337"></div>
+
+<p>Matrices</p>
+<div class="example mathml mmlcore">
+<pre>
+&lt;mtable intent="array">
+  &lt;mtr intent="arrayrow">
+    &lt;mtd>&lt;mn>1&lt;/mn>&lt;/mtd>
+    &lt;mtd>&lt;mn>0&lt;/mn>&lt;/mtd>
+  &lt;/mtr>
+  &lt;mtr intent="arrayrow">
+    &lt;mtd>&lt;mn>0&lt;/mn>&lt;/mtd>
+    &lt;mtd>&lt;mn>1&lt;/mn>&lt;/mtd>
+  &lt;/mtr>
+&lt;/mtable>
+</pre>
+</div>
+
+
+<p>Aligned equations</p>
+<div class="example mathml mmlcore">
+<pre>
+&lt;mtable intent="list">
+  &lt;mtr intent="append">
+    &lt;mtd columnalign="right">
+      &lt;mn>2&lt;/mn>
+      &lt;mo>&#x2062;&lt;/mo>
+      &lt;mi>x&lt;/mi>
+    &lt;/mtd>
+    &lt;mtd columnalign="center">
+      &lt;mo>=&lt;/mo>
+    &lt;/mtd>
+    &lt;mtd columnalign="left">
+      &lt;mn>1&lt;/mn>
+    &lt;/mtd>
+  &lt;/mtr>
+  &lt;mtr intent="append">
+    &lt;mtd columnalign="right">
+      &lt;mi>y&lt;/mi>
+    &lt;/mtd>
+    &lt;mtd columnalign="center">
+      &lt;mo>&gt;&lt;/mo>
+    &lt;/mtd>
+    &lt;mtd columnalign="left">
+      &lt;mi>x&lt;/mi>
+      &lt;mo>-&lt;/mo>
+      &lt;mn>3&lt;/mn>
+    &lt;/mtd>
+  &lt;/mtr>
+&lt;/mtable>
+</pre>
+</div>
+
+<p>Aligned Equations with wrapped expressions</p>
+
+<div class="example mathml mmlcore">
+<pre>
+&lt;mtable intent="list">
+  &lt;mtr intent="append">
+    &lt;mtd columnalign="right">
+      &lt;mi>a&lt;/mi>
+    &lt;/mtd>
+    &lt;mtd columnalign="center">
+      &lt;mo>=&lt;/mo>
+    &lt;/mtd>
+    &lt;mtd columnalign="left">
+      &lt;mi>b&lt;/mi>
+      &lt;mo>+&lt;/mo>
+      &lt;mi>c&lt;/mi>
+      &lt;mo>-&lt;/mo>
+      &lt;mi>d&lt;/mi>
+    &lt;/mtd>
+  &lt;/mtr>
+  &lt;mtr intent="extend">
+    &lt;mtd columnalign="right">&lt;/mtd>
+    &lt;mtd columnalign="center">&lt;/mtd>
+    &lt;mtd columnalign="left">
+      &lt;mo>+&lt;/mo>
+      &lt;mi>e&lt;/mi>
+      &lt;mo>-&lt;/mo>
+      &lt;mi>f&lt;/mi>
+    &lt;/mtd>
+  &lt;/mtr>
+&lt;/mtable>
+</pre>
+</div>
+ </section>
+ </section>
+ 
  </section>
 
  <section>

--- a/src/mixing.html
+++ b/src/mixing.html
@@ -196,16 +196,20 @@ topics.</p>
 <p>Matrices</p>
 <div class="example mathml mmlcore">
 <pre>
-&lt;mtable intent="array">
-  &lt;mtr intent="arrayrow">
-    &lt;mtd>&lt;mn>1&lt;/mn>&lt;/mtd>
-    &lt;mtd>&lt;mn>0&lt;/mn>&lt;/mtd>
-  &lt;/mtr>
-  &lt;mtr intent="arrayrow">
-    &lt;mtd>&lt;mn>0&lt;/mn>&lt;/mtd>
-    &lt;mtd>&lt;mn>1&lt;/mn>&lt;/mtd>
-  &lt;/mtr>
-&lt;/mtable>
+&lt;mrow intent="matrix">
+  &lt;mo>(&lt;/mo>
+  &lt;mtable>
+    &lt;mtr intent="arrayrow">
+        &lt;mtd>&lt;mn>1&lt;/mn>&lt;/mtd>
+      &lt;mtd>&lt;mn>0&lt;/mn>&lt;/mtd>
+    &lt;/mtr>
+    &lt;mtr intent="arrayrow">
+      &lt;mtd>&lt;mn>0&lt;/mn>&lt;/mtd>
+      &lt;mtd>&lt;mn>1&lt;/mn>&lt;/mtd>
+    &lt;/mtr>
+  &lt;/mtable>
+  &lt;mo>)&lt;/mo>
+&lt;/mrow>
 </pre>
 </div>
 

--- a/src/mixing.html
+++ b/src/mixing.html
@@ -133,6 +133,10 @@ a derivative or an embellished symbol. These cases would be distinguished as fol
   &lt;mo>&amp;prime;&lt;/mo>
 &lt;/msup>
 </pre>
+<p>Possible readings with and without <code class="attribute">intent</code></p>
+<blockquote>x to the n-th power, right arrow A transpose right arrow derivative of, f, right arrow literal x′</blockquote>
+<blockquote>x to the n-th power, right arrow A transpose right arrow f prime, right arrow x prime,</blockquote>
+<p class="ednote">mathcat gets transpose even without intent</p>
 </div>
 
 <p>Similarly an over bar may represent complex conjugation, or mean (average):</p>
@@ -149,6 +153,10 @@ a derivative or an embellished symbol. These cases would be distinguished as fol
   &lt;mo&gt;&amp;#xaf;&lt;/mo&gt;
 &lt;/mover&gt;
 </pre>
+<p>Possible readings with and without <code class="attribute">intent</code></p>
+<blockquote>conjugate of, z  is not  mean of, X</blockquote>
+<blockquote>z with ¯ above  is not  X with ¯ above</blockquote>
+<p class="ednote">This makes bettter example</p>
 </div>
 
  </section>
@@ -164,9 +172,13 @@ a derivative or an embellished symbol. These cases would be distinguished as fol
 <pre>
 &lt;msub intent="bell-number($index)"&gt;
   &lt;mi&gt;B&lt;/mi&gt;
-  &lt;mn arg="index"&gt;2&lt;/m&gt;
+  &lt;mn arg="index"&gt;2&lt;/mn&gt;
 &lt;/msub&gt;
 </pre>
+<p>Possible readings with and without <code class="attribute">intent</code></p>
+<blockquote>bell number of, literal 2</blockquote>
+<blockquote>B sub 2</blockquote>
+
 </div>
 
 <p>Here the subscripted B denoting the <em>Bell Number</em> is annotated using

--- a/src/mixing.html
+++ b/src/mixing.html
@@ -272,7 +272,7 @@ topics.</p>
     &lt;mtd columnalign="right">&lt;/mtd>
     &lt;mtd columnalign="center">&lt;/mtd>
     &lt;mtd columnalign="left">
-      &lt;mo>+&lt;/mo>
+      &lt;mo form="infix">+&lt;/mo>
       &lt;mi>e&lt;/mi>
       &lt;mo>-&lt;/mo>
       &lt;mi>f&lt;/mi>


### PR DESCRIPTION
Starting to add a bit more structure to chapter 5, still mostly just adding editorial notes and stub text but replacing some of the current text that makes no gramatical sense as it was just copied without context from earlier documents.

I suggest that this is merged more or less as is, even if none of his text will survive to the public draft, to allow more people to see/comment on intent descriptions.

@NSoiffer I added some mathcat generated text but I may not have chosen the best options.... (I seem to have used clear speak / verbose / plain)