### PR TITLE
first attempt at referencing polyfills

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,7 +86,6 @@
         sorttable.makeSortable(document.getElementById('oper-dict-table'));
     }
     function mmlpolyfill () {
-	document.querySelectorAll("div.mml4p").forEach((div) => transform(div));
 	document.querySelectorAll("math.mml4p").forEach((div) => transform(div));
     }
     function showcore (){

--- a/index.html
+++ b/index.html
@@ -7,6 +7,14 @@
       src='https://www.w3.org/Tools/respec/respec-w3c'
       class='remove'>
   </script>
+  <script type="module" class='remove'>
+        import { _MathTransforms } from 'https://mathml-refresh.github.io/mathml-polyfills/all-polyfills.js'
+
+        document.head.appendChild ( _MathTransforms.getCSSStyleSheet() );
+        window.transform = function (elementId) {
+            _MathTransforms.transform(elementId);
+        }
+  </script>
   <script src="sorttable.js"></script>
   <script class='remove'>
     function relaxhl (r,s,u) {
@@ -77,6 +85,10 @@
     function resortable () {
         sorttable.makeSortable(document.getElementById('oper-dict-table'));
     }
+    function mmlpolyfill () {
+	document.querySelectorAll("div.mml4p").forEach((div) => transform(div));
+	document.querySelectorAll("math.mml4p").forEach((div) => transform(div));
+    }
     function showcore (){
 	var mmllist=document.querySelectorAll("div.example.mathml");
 	for(var i=0;i!=mmllist.length;i++){
@@ -137,7 +149,7 @@
            }]
                    }],
   github:        "https://github.com/w3c/mathml",
-       postProcess:   [mmlindex,foldable,resortable,showcore],
+       postProcess:   [mmlindex,foldable,resortable,showcore,mmlpolyfill],
   localBiblio: {
   "MathML1":           {"aliasOf": "MathML-19980407"},
   "MathML-Core":       {"aliasOf": "mathml-core"},

--- a/index.html
+++ b/index.html
@@ -160,7 +160,7 @@
   "XMLSchemas":        {"aliasOf": "xmlschema-1"},
   "XMLSchemaDatatypes":{"aliasOf": "xmlschema-2"},
   "XHTML-MathML-SVG":  {"aliasOf": "XHTMLplusMathMLplusSVG"},
-  "SVG1.1":            {"aliasOf": "SVG11"},       
+  "SVG":               {"aliasOf": "SVG11"},       
 
   "MathML-Notes": {"title": "Notes on MathML",
                    "publisher": "W3C",

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
       src='https://www.w3.org/Tools/respec/respec-w3c'
       class='remove'>
   </script>
-  <script type="module" class='remove'>
+  <script type="module" class='removeOnSave'>
         import { _MathTransforms } from 'https://mathml-refresh.github.io/mathml-polyfills/all-polyfills.js'
 
         document.head.appendChild ( _MathTransforms.getCSSStyleSheet() );

--- a/index.html
+++ b/index.html
@@ -98,7 +98,7 @@
 	    m.setAttribute("class",
 			   mclass.replace("example mathml","") +
 			   " inlinemath");
-	    m.innerHTML=mmllist[i].textContent;
+	    m.innerHTML=mmllist[i].querySelector("pre").textContent;
 	    var atext;
 	    var aattrib=mmllist[i].getAttribute("alttext");
 	    if (aattrib)  {

--- a/src/abstract.html
+++ b/src/abstract.html
@@ -38,7 +38,7 @@
    <p>MathML was originally specified as an XML application and most of the
    examples in this specification assume that syntax. Other syntaxes are possible most
    notably
-   [[HTML5]] specifies the syntax for MathML in HTML. Unless explicitly noted,
+   [[HTML]] specifies the syntax for MathML in HTML. Unless explicitly noted,
    the examples in this specification are also valid HTML syntax.
    </p>
 </section>

--- a/src/changes.html
+++ b/src/changes.html
@@ -84,7 +84,7 @@
     </li>
     <li>In Mathml&#160; table rows and cells must be explicitly marked
     wih <code class="element">mtr</code> and <code
-    class="element">mtd</code>. The [[MathML1]] required that an
+    class="element">mtd</code>. The [[?MathML1]] required that an
     implementation infer the row markup if it was omitted.
     </li>
 
@@ -132,7 +132,7 @@
     class="element">&lt;semanics&gt;</code> element to mix
     Presentation and Content MathML is maintained in the second
     section, although reduced with some non normative text and
-    examples moved to [[MathML-Notes]].</li>
+    examples moved to [[?MathML-Notes]].</li>
 
     <li>MathML&#160;3 deprecated the use of <code
     class="attribute">encoding</code> and <code
@@ -154,7 +154,7 @@
     <li>The schema was refactored with a new `mathml4-core` schema
     matching [[MathML-Core]] being used as the basis for
     `mathml4-presentation`, and a new `mathml4-legacy` schema that can
-    be used to validate an existing corpus of documents matching [[MathML3]].</li>
+    be used to validate an existing corpus of documents matching [[?MathML3]].</li>
    </ul>
 
   </section>

--- a/src/conformance.html
+++ b/src/conformance.html
@@ -264,7 +264,7 @@
    remaining strictly in conformance with the standard
    DTD.</p>
 
-   <p>To allow this, the MathML 1.0 specification [[MathML1]]]
+   <p>To allow this, the MathML 1.0 specification [[?MathML1]]]
    allowed the attribute <code class="attribute">other</code> on all elements, for use as a hook to pass
    on renderer-specific information. In particular, it was intended as a hook for
    passing information to audio renderers, computer algebra systems, and for pattern

--- a/src/contm-new.html
+++ b/src/contm-new.html
@@ -43,9 +43,9 @@
    and geographical regions. For example, many notations for long
    division are in use in different parts of the world today. Notations
    may lose currency, for example the use of musical sharp and flat
-   symbols to denote maxima and minima [[Chaundy1954]]. A
+   symbols to denote maxima and minima [[?Chaundy1954]]. A
    notation in use in 1644 for the multiplication mentioned above was
-   <img src="image/f4001.gif" alt="\blacksquare" class="vmiddle"></img><i class="var">H</i><i class="var">e</i> [[Cajori1928]].</p>
+   <img src="image/f4001.gif" alt="\blacksquare" class="vmiddle"></img><i class="var">H</i><i class="var">e</i> [[?Cajori1928]].</p>
 
    <p>By encoding the underlying mathematical structure explicitly,
    without regard to how it is presented aurally or visually, it is
@@ -998,7 +998,7 @@
      inappropriate.  Advanced types require significant structure of their own (for example,
      <i class="var">vector(complex)</i>) and are probably best constructed as mathematical objects and
      then associated with a MathML expression through use of the <code class="element">semantics</code>
-     element. See [[mathml-types]] for more examples.</p>
+     element. See [[?mathml-types]] for more examples.</p>
 
     </section>
 
@@ -1190,7 +1190,7 @@
      <p>The resulting URI is specified as the value of the <code class="attribute">definitionURL</code> attribute.</p>
 
      <p>This form of reference is useful for backwards compatibility with MathML2 and to
-     facilitate the use of Content MathML within URI-based frameworks (such as RDF [[rdf]] in the Semantic Web or OMDoc [[OMDoc1.2]]).  Another benefit is
+     facilitate the use of Content MathML within URI-based frameworks (such as RDF [[?rdf]] in the Semantic Web or OMDoc [[?OMDoc1.2]]).  Another benefit is
      that the symbol name in the CD does not need to correspond to the content of the
      <code class="element">csymbol</code> element.  However, in general, this method results in much longer MathML
      instances.  Also, in situations where CDs are under development, the use of a CD Group
@@ -6605,7 +6605,7 @@
 represent respectively:<br/>
 the base of the natural logarithm, approximately 2.718;<br/>
 the square root of -1, commonly written <i class="var">i</i>;<br/>
-not-a-number, i.e. the result of an ill-posed floating point computation (see [[IEEE754]]);<br/>
+not-a-number, i.e. the result of an ill-posed floating point computation (see [[?IEEE754]]);<br/>
 the Boolean value true;<br/>
 the Boolean value false;<br/>
 pi (<i class="var">&#x03c0;</i>), approximately 3.142, which is the ratio of the circumference of a circle to its diameter;<br/>

--- a/src/contributors.html
+++ b/src/contributors.html
@@ -1,4 +1,4 @@
-<section class="appendix">
+<section class="appendix informative">
  <h2 id="contributors">Working Group Membership and Acknowledgments</h2>
 
  <section>

--- a/src/mixing.html
+++ b/src/mixing.html
@@ -81,58 +81,193 @@ the user and agent.</p>
   <section>
    <h4 id="mixing_intent_grammar">The Grammar for <code class="attribue">intent</code></h4>
 
- <pre class="def bnf">
+   <p>The <code class="attribute">intent</code>, after ignoring white
+   space between tokens, should match the following grammar.</p>
+   
+<pre class="def bnf">
 intent   := number | NCName | argref | function
 function := (NCName | argref) '(' intent [ ',' intent ]* ')'
 number   := '-'? digit+ ('.' digit+)? 
 argref   := '$' NCName
-   </pre>
+</pre>
 
+<p>Here <a href="https://www.w3.org/TR/REC-xml-names/#NT-NCName"><code>NCName</code></a>
+is as defined in  in [[xml-names]], and <code>digit</code> is a character in the range 0–9.</p>
   </section>
 
 
 
  <section>
-  <h3 id="mixing_intent_examplesn">Intent Examples</h3>
+  <h3 id="mixing_intent_examples">Intent Examples</h3>
 
-<p>With this model, the <code class="element">msup</code> examples:
-as a power;
-as a transpose;
-as a derivative; and
-as an embellished symbol would be distinguished as follows:</p>
+  
+ <section>
+  <h4 id="mixing_intent_examples_notation">Ambiguous Notation</h4>
 
-<pre class="xml nonumexample">
+  <p>A primary use for <code class="attribute">intent</code> is to
+  disambiguate cases where the same syntax is used for different meanings,
+  and typically has different readings.</p>
+  
+<p>Superscript, <code class="element">msup</code>, may represent a power, a transpose,
+a derivative or an embellished symbol. These cases would be distinguished as follows:</p>
+
+<div class="example mathml mmlcore">
+<pre>
 &lt;msup intent="power($base,$exp)">
   &lt;mi arg="base">x&lt;/mi>
   &lt;mi arg="exp">n&lt;/mi>
 &lt;/msup>
-</pre>
-
-<pre class="xml nonumexample">
+&lt;mo>&#x2192;&lt;/mo>
 &lt;msup intent="$op($a)">
   &lt;mi arg="a">A&lt;/mi>
   &lt;mi arg="op" intent="transpose">T&lt;/mi>
 &lt;/msup>
-</pre>
-
-<p>(easily adapted to conjugate and adjoint)</p>
-
-<pre class="xml nonumexample">
+&lt;mo>&#x2192;&lt;/mo>
 &lt;msup intent="derivative($a)">
   &lt;mi arg="a">f&lt;/mi>
-  &lt;mi>'&lt;/mi>
+  &lt;mi>&amp;prime;&lt;/mi>
 &lt;/msup>
-</pre>
-
-<pre class="xml nonumexample">
+&lt;mo>&#x2192;&lt;/mo>
 &lt;msup intent="x-prime">
   &lt;mi>x&lt;/mi>
-  &lt;mo>'&lt;/mo>
+  &lt;mo>&amp;prime;&lt;/mo>
 &lt;/msup>
 </pre>
+</div>
 
+<p>Similarly an over bar may represent complex conjugation, or mean (average):</p>
+
+<div class="example mathml mmlcore">
+<pre>
+&lt;mover intent="conjugate($v)"&gt;
+  &lt;mi arg="v"&gt;z&lt;/mi&gt;
+  &lt;mo&gt;&amp;#xaf;&lt;/mo&gt;
+&lt;/mover&gt;
+&lt;mtext>&amp;nbsp;is not&amp;nbsp;&lt;/mtext>
+&lt;mover intent="mean($var)"&gt;
+  &lt;mi arg="var"&gt;X&lt;/mi&gt;
+  &lt;mo&gt;&amp;#xaf;&lt;/mo&gt;
+&lt;/mover&gt;
+</pre>
+</div>
 
  </section>
+
+ <section>
+  <h4 id="mixing_intent_examples_advanced">Advanced or Non-Standard Notation</h4>
+
+  <p>A special case of ambiguous notation is the re-use of standard
+  notation with meaning that may be specific to a subject area or evn
+  individual document,</p>
+  
+<div class="example mathml mmlcore">
+<pre>
+&lt;msub intent="bell-number($index)"&gt;
+  &lt;mi&gt;B&lt;/mi&gt;
+  &lt;mn arg="index"&gt;2&lt;/m&gt;
+&lt;/msub&gt;
+</pre>
+</div>
+
+<p>Here the subscripted B denoting the <em>Bell Number</em> is annotated using
+<code>bell-number</code> intent which is not in the core <q>Level 1</q>
+dictionary but is in the open <q>Level 3</q> dictionary of more advanced or specialist
+topics.</p>
+ 
+ </section>
+
+ 
+ <section>
+  <h4 id="mixing_intent_examples_mtr">Tables</h4>
+<div class="issue"  data-number="337"></div>
+
+<p>Matrices</p>
+<div class="example mathml mmlcore">
+<pre>
+&lt;mtable intent="array">
+  &lt;mtr intent="arrayrow">
+    &lt;mtd>&lt;mn>1&lt;/mn>&lt;/mtd>
+    &lt;mtd>&lt;mn>0&lt;/mn>&lt;/mtd>
+  &lt;/mtr>
+  &lt;mtr intent="arrayrow">
+    &lt;mtd>&lt;mn>0&lt;/mn>&lt;/mtd>
+    &lt;mtd>&lt;mn>1&lt;/mn>&lt;/mtd>
+  &lt;/mtr>
+&lt;/mtable>
+</pre>
+</div>
+
+
+<p>Aligned equations</p>
+<div class="example mathml mmlcore">
+<pre>
+&lt;mtable intent="list">
+  &lt;mtr intent="append">
+    &lt;mtd columnalign="right">
+      &lt;mn>2&lt;/mn>
+      &lt;mo>&#x2062;&lt;/mo>
+      &lt;mi>x&lt;/mi>
+    &lt;/mtd>
+    &lt;mtd columnalign="center">
+      &lt;mo>=&lt;/mo>
+    &lt;/mtd>
+    &lt;mtd columnalign="left">
+      &lt;mn>1&lt;/mn>
+    &lt;/mtd>
+  &lt;/mtr>
+  &lt;mtr intent="append">
+    &lt;mtd columnalign="right">
+      &lt;mi>y&lt;/mi>
+    &lt;/mtd>
+    &lt;mtd columnalign="center">
+      &lt;mo>&gt;&lt;/mo>
+    &lt;/mtd>
+    &lt;mtd columnalign="left">
+      &lt;mi>x&lt;/mi>
+      &lt;mo>-&lt;/mo>
+      &lt;mn>3&lt;/mn>
+    &lt;/mtd>
+  &lt;/mtr>
+&lt;/mtable>
+</pre>
+</div>
+
+<p>Aligned Equations with wrapped expressions</p>
+
+<div class="example mathml mmlcore">
+<pre>
+&lt;mtable intent="list">
+  &lt;mtr intent="append">
+    &lt;mtd columnalign="right">
+      &lt;mi>a&lt;/mi>
+    &lt;/mtd>
+    &lt;mtd columnalign="center">
+      &lt;mo>=&lt;/mo>
+    &lt;/mtd>
+    &lt;mtd columnalign="left">
+      &lt;mi>b&lt;/mi>
+      &lt;mo>+&lt;/mo>
+      &lt;mi>c&lt;/mi>
+      &lt;mo>-&lt;/mo>
+      &lt;mi>d&lt;/mi>
+    &lt;/mtd>
+  &lt;/mtr>
+  &lt;mtr intent="extend">
+    &lt;mtd columnalign="right">&lt;/mtd>
+    &lt;mtd columnalign="center">&lt;/mtd>
+    &lt;mtd columnalign="left">
+      &lt;mo>+&lt;/mo>
+      &lt;mi>e&lt;/mi>
+      &lt;mo>-&lt;/mo>
+      &lt;mi>f&lt;/mi>
+    &lt;/mtd>
+  &lt;/mtr>
+&lt;/mtable>
+</pre>
+</div>
+ </section>
+ </section>
+ 
  </section>
 
  <section>

--- a/src/mixing.html
+++ b/src/mixing.html
@@ -196,16 +196,20 @@ topics.</p>
 <p>Matrices</p>
 <div class="example mathml mmlcore">
 <pre>
-&lt;mtable intent="array">
-  &lt;mtr intent="arrayrow">
-    &lt;mtd>&lt;mn>1&lt;/mn>&lt;/mtd>
-    &lt;mtd>&lt;mn>0&lt;/mn>&lt;/mtd>
-  &lt;/mtr>
-  &lt;mtr intent="arrayrow">
-    &lt;mtd>&lt;mn>0&lt;/mn>&lt;/mtd>
-    &lt;mtd>&lt;mn>1&lt;/mn>&lt;/mtd>
-  &lt;/mtr>
-&lt;/mtable>
+&lt;mrow intent="matrix">
+  &lt;mo>(&lt;/mo>
+  &lt;mtable>
+    &lt;mtr intent="arrayrow">
+        &lt;mtd>&lt;mn>1&lt;/mn>&lt;/mtd>
+      &lt;mtd>&lt;mn>0&lt;/mn>&lt;/mtd>
+    &lt;/mtr>
+    &lt;mtr intent="arrayrow">
+      &lt;mtd>&lt;mn>0&lt;/mn>&lt;/mtd>
+      &lt;mtd>&lt;mn>1&lt;/mn>&lt;/mtd>
+    &lt;/mtr>
+  &lt;/mtable>
+  &lt;mo>)&lt;/mo>
+&lt;/mrow>
 </pre>
 </div>
 

--- a/src/mixing.html
+++ b/src/mixing.html
@@ -133,6 +133,10 @@ a derivative or an embellished symbol. These cases would be distinguished as fol
   &lt;mo>&amp;prime;&lt;/mo>
 &lt;/msup>
 </pre>
+<p>Possible readings with and without <code class="attribute">intent</code></p>
+<blockquote>x to the n-th power, right arrow A transpose right arrow derivative of, f, right arrow literal x′</blockquote>
+<blockquote>x to the n-th power, right arrow A transpose right arrow f prime, right arrow x prime,</blockquote>
+<p class="ednote">mathcat gets transpose even without intent</p>
 </div>
 
 <p>Similarly an over bar may represent complex conjugation, or mean (average):</p>
@@ -149,6 +153,10 @@ a derivative or an embellished symbol. These cases would be distinguished as fol
   &lt;mo&gt;&amp;#xaf;&lt;/mo&gt;
 &lt;/mover&gt;
 </pre>
+<p>Possible readings with and without <code class="attribute">intent</code></p>
+<blockquote>conjugate of, z  is not  mean of, X</blockquote>
+<blockquote>z with ¯ above  is not  X with ¯ above</blockquote>
+<p class="ednote">This makes bettter example</p>
 </div>
 
  </section>
@@ -164,9 +172,13 @@ a derivative or an embellished symbol. These cases would be distinguished as fol
 <pre>
 &lt;msub intent="bell-number($index)"&gt;
   &lt;mi&gt;B&lt;/mi&gt;
-  &lt;mn arg="index"&gt;2&lt;/m&gt;
+  &lt;mn arg="index"&gt;2&lt;/mn&gt;
 &lt;/msub&gt;
 </pre>
+<p>Possible readings with and without <code class="attribute">intent</code></p>
+<blockquote>bell number of, literal 2</blockquote>
+<blockquote>B sub 2</blockquote>
+
 </div>
 
 <p>Here the subscripted B denoting the <em>Bell Number</em> is annotated using

--- a/src/mixing.html
+++ b/src/mixing.html
@@ -272,7 +272,7 @@ topics.</p>
     &lt;mtd columnalign="right">&lt;/mtd>
     &lt;mtd columnalign="center">&lt;/mtd>
     &lt;mtd columnalign="left">
-      &lt;mo>+&lt;/mo>
+      &lt;mo form="infix">+&lt;/mo>
       &lt;mi>e&lt;/mi>
       &lt;mo>-&lt;/mo>
       &lt;mi>f&lt;/mi>

--- a/src/mixing.html
+++ b/src/mixing.html
@@ -752,7 +752,7 @@ as an embellished symbol would be distinguished as follows:</p>
     <code class="element">annotation-xml</code> element, however they would be placed in the <em>MathML</em> namespace. The above examples are not rendered in the HTML version of this specification,
     to ensure that that document is a valid HTML5 document.</p>
 
-    <p>The details of the HTML parser handling of <code class="element">annotation-xml</code> is specified in [[HTML5]] and summarized in <a href="#interf_html"></a>, however the main differences from the behavior of an XML parser that affect MathML
+    <p>The details of the HTML parser handling of <code class="element">annotation-xml</code> is specified in [[HTML]] and summarized in <a href="#interf_html"></a>, however the main differences from the behavior of an XML parser that affect MathML
     annotations are that the HTML parser does not treat <code>xmlns</code> attributes, nor <code>:</code> in element names as special and has built-in rules determining whether the three
     <q>known</q> namespaces, HTML, SVG or MathML are used.
     </p>

--- a/src/parsing-2.html
+++ b/src/parsing-2.html
@@ -2,7 +2,7 @@
  <h3 id="parsing_usingdtd">Using the MathML DTD</h3>
 
  <p>The MathML DTD uses the strategy outlined in
- [[Modularization]] to allow the use of namespace prefixes
+ [[?Modularization]] to allow the use of namespace prefixes
  on MathML elements. However it is recommended that
  namespace prefixes are not used in XML serialization of
  MathML, for compatibility with the HTML serialization.</p>

--- a/src/presentation-markup.html
+++ b/src/presentation-markup.html
@@ -1188,7 +1188,7 @@
    can be either represented directly as Unicode character data, or indirectly via numeric
    or character entity references.
    Unicode contains a number of look-alike characters.
-   See [[MathML-Notes]] for a discussion of which characters are appropriate to use in which circumstance.
+   See [[?MathML-Notes]] for a discussion of which characters are appropriate to use in which circumstance.
    </p>
  
    <p>Token elements (other than <code class="element">mspace</code>) should
@@ -1463,7 +1463,7 @@
    predefined selectors for CSS style rules.
    See <a href="#world-int-style"></a> for discussion of the
    interaction of MathML and CSS.
-   Also, see [[MathMLforCSS]] for discussion of rendering MathML by CSS
+   Also, see [[?MathMLforCSS]] for discussion of rendering MathML by CSS
    and a sample CSS style sheet.
    When CSS is not available, it is up to the internal style mechanism of the rendering
    application
@@ -3261,7 +3261,7 @@
  
  <p>See also the warnings about the legal grouping of <q>space-like elements</q>
  in <a href="#presm_mspace"></a>, and about the use of
- such elements for <q>tweaking</q> in [[MathML-Notes]].</p>
+ such elements for <q>tweaking</q> in [[?MathML-Notes]].</p>
  </section>
  
  <section class="fold">
@@ -3296,7 +3296,7 @@
  
  <p>Note the warning about the legal grouping of <q>space-like
  elements</q> given below, and the warning about the use of such
- elements for <q>tweaking</q> in [[MathML-Notes]].
+ elements for <q>tweaking</q> in [[?MathML-Notes]].
  See also the other elements that can render as
  whitespace, namely <code class="element">mtext</code>, <code class="element">mphantom</code>, and
  <code class="element">maligngroup</code>.</p> </section>
@@ -3514,7 +3514,7 @@
  </div>
  
  <p>See also the warning about <q>tweaking</q> in
-   [[MathML-Notes]].</p>
+   [[?MathML-Notes]].</p>
  </section>
  </section>
  
@@ -4561,7 +4561,7 @@
    used to make more general adjustments <span>of </span>size and positioning, and some
    combinations, e.g. negative padding, can cause the content of
    <code class="element">mpadded</code> to overlap the rendering of neighboring content.  See
-   [[MathML-Notes]] for warnings about several
+   [[?MathML-Notes]] for warnings about several
    potential pitfalls of this effect.</p>
  
    <p>The <code class="element">mpadded</code> element accepts

--- a/src/presentation-markup.html
+++ b/src/presentation-markup.html
@@ -9063,10 +9063,10 @@
  </section>
  </section>
  
- <section class="fold">
+ <section>
  <h4 id="presm_elemmath_examples">Elementary Math Examples</h4>
  
- <section>
+ <section class="fold">
  <h5 id="presm_addsub">Addition and Subtraction</h5>
  
  <p>Two-dimensional addition, subtraction, and multiplication typically
@@ -9203,7 +9203,7 @@
  
  </section>
  
- <section>
+ <section class="fold">
  <h5 id="presm_mult">Multiplication</h5>
  
  <p>Below is a simple multiplication example that illustrates the use of <code class="element">msgroup</code> and
@@ -9276,7 +9276,7 @@
  
  </section>
  
- <section>
+ <section class="fold">
  <h5 id="presm_mlongdiv_ex">Long Division</h5>
  
  <p>
@@ -9479,7 +9479,7 @@
  
  </section>
  
- <section>
+ <section class="fold">
  <h5 id="presm_repeatdec">Repeating decimal</h5>
  
  <p>

--- a/src/world-interactions.html
+++ b/src/world-interactions.html
@@ -11,7 +11,7 @@
   some of the interface issues involved in generating and rendering
   MathML. Since MathML exists primarily to encode mathematics in Web
   documents, perhaps the most important interface issues relate to
-  embedding MathML in [[HTML5]], <span> and
+  embedding MathML in [[HTML]], <span> and
   [[XHTML]], and in any newer HTML
   when it appears</span>.</p>
 
@@ -971,13 +971,13 @@
   <section>
    <h4 id="interf_html">Mixing MathML and HTML</h4>
 
-   <p>An important example of a non-XML based system is defined in [[HTML5]]. When
+   <p>An important example of a non-XML based system is defined in [[HTML]]. When
    considering MathML in HTML there are two separate issues to consider. Firstly the
    schema is extended
    to allow HTML in <code class="element">mtext</code> as described above in the context of XHTML. Secondly an HTML parser
    is used rather than an XML parser. The parsing of MathML by an HTML parser is normatively
    defined in
-   [[HTML5]]. The description there is aimed at parser implementers and written in terms of
+   [[HTML]]. The description there is aimed at parser implementers and written in terms of
    the state transitions of the parser as it parses each character of the input. The
    <em>non-normative</em> description below aims to give a higher level description and
    examples.</p>

--- a/src/world-interactions.html
+++ b/src/world-interactions.html
@@ -1163,7 +1163,7 @@
    representations of the MathML-Content depiction of the
    intersection of two sets.
    The first one is in the <q>Scalable Vector
-   Graphics</q> format [[SVG1.1]]
+   Graphics</q> format [[SVG]]
    (see [[XHTML-MathML-SVG]] for the definition of an XHTML profile integrating MathML and SVG), the second one
    uses the
    XHTML <code class="element" data-namespace="xhtml">img</code> element embedded as an XHTML fragment.

--- a/src/world-interactions.html
+++ b/src/world-interactions.html
@@ -1164,7 +1164,7 @@
    intersection of two sets.
    The first one is in the <q>Scalable Vector
    Graphics</q> format [[SVG]]
-   (see [[XHTML-MathML-SVG]] for the definition of an XHTML profile integrating MathML and SVG), the second one
+   (see [[?XHTML-MathML-SVG]] for the definition of an XHTML profile integrating MathML and SVG), the second one
    uses the
    XHTML <code class="element" data-namespace="xhtml">img</code> element embedded as an XHTML fragment.
    In this situation, a MathML processor can use any of these

--- a/src/world-interactions.html
+++ b/src/world-interactions.html
@@ -34,7 +34,7 @@
   common. Using these browser-specific mechanisms generally requires
   additional interface markup of some sort to activate them.  In the
   case of CSS, there is a special restricted form of MathML3
-  [[MathMLforCSS]] that is tailored for use with
+  [[?MathMLforCSS]] that is tailored for use with
   CSS rendering engines that support CSS 2.1 [[CSS21]].
   This restricted profile of MathML3 does not offer the full
   expressiveness of MathML3, but it provides a portable simpler form


### PR DESCRIPTION
@NSoiffer  This adds the combined polyfill to the respec post filter and it seems to mosly work, but I guess it has lost some CSS along the way, the alignment in `<mscarries` is off and `<msline` isn't appearing,.

The console shows

GET `http://localhost:8080/w3c/mathml/elem-math/elemMath.css` is 404

but that CSS comes from inside the polyfill JavaScript so no sure how best to get it to use 
https://mathml-refresh.github.io/mathml-polyfills/elem-math/elemMath.css
I tried adding a link to that "from the ouside" but without any effect.

I think I got as far as I can go, can you pick his up, either pushing to this branch, or merging anyway and then fixing in a later PR?

the mscarries example looks like this:

![image](https://user-images.githubusercontent.com/1268738/169692428-08f03422-e65f-4d81-8448-32b1edd82930.png)
