### PR TITLE
Separated operator content and attribute tables

### DIFF
--- a/index.html
+++ b/index.html
@@ -299,6 +299,8 @@ math.inlinemath.mml4c {
 img.vmiddle {vertical-align: middle}
 #contm_ops_table td {padding: 0em 1em;}
 #contm_ops_table tr > :nth-child(3) {white-space: nowrap;}
+#contm_atts_table td {padding: 0em 1em;}
+#contm_constr_table td {padding: 0em 1em;}
 div.issue > *:not(:first-child) {display:none;}
 div.issue > *:nth-child(2) {display:block;}
 

--- a/src/contm-new.html
+++ b/src/contm-new.html
@@ -2381,28 +2381,19 @@
     <h4 id="contm_container">Container Markup</h4>
 
     <p>Many mathematical structures are constructed from subparts or
-    parameters. The motivating example is a set. Informally, one
-    thinks of a set as a certain kind of mathematical object that
-    contains a collection of elements. Thus, it is intuitively natural
-    for the markup for a set to contain, in the XML sense, the markup
-    for its constituent elements. The markup may define the set
-    elements explicitly by enumerating them, or implicitly by rule,
-    using qualifier elements. However, in either case, the markup for
-    the elements is contained in the markup for the set, and
-    consequently this style of representation is termed
-    <em>container markup</em> in MathML. By contrast, Strict
-    markup represents an instance of a set as the result of applying a
-    function or <em>constructor symbol</em> to arguments.  In this
-    style of markup, the markup for the set construction is a sibling
-    of the markup for the set elements in an enclosing <code class="element">apply</code>
-    element.</p>
-
-    <p>While the two approaches are formally equivalent, container
-    markup is generally more intuitive for non-expert authors to use, while
-    Strict markup is preferable is contexts where semantic rigor is
-    paramount.  In addition, MathML 2 relied on container markup, and
-    thus container markup is necessary in cases where backward
-    compatibility is required.</p>
+    parameters. For example, a set as a mathematical object that
+    contains a collection of elements, so it is natural for the
+    markup for a set to contain the markup for its constituent
+    elements. The markup for a set may define the set of elements
+    explicitly by enumerating them, or implicitly by rule that uses
+    qualifier elements. In either case, the markup for the elements is
+    contained in the markup for the set, and this style of
+    representation is called <em>container markup</em> in MathML. By
+    contrast, Strict markup represents an instance of a set as the
+    result of applying a function or <em>constructor symbol</em> to
+    arguments.  In this style of markup, the markup for the set
+    construction is a sibling of the markup for the set elements in an
+    enclosing <code class="element">apply</code> element.</p>
 
     <p>MathML provides container markup for the following mathematical
     constructs: sets, lists, intervals, vectors, matrices (two
@@ -2416,21 +2407,19 @@
     operator involved.  For details about a specific container
     element, obtain its operator class (and any applicable special
     case information) by consulting the syntax table and discussion
-    for that element in <a href="#contm_structure_extended"></a>. Then apply the
+    for that element in <a href="#contm_ops_syntax"></a>. Then apply the
     rewrite rules for that specific operator class as described in
-    <a href="#contm_opclasses"></a>.</p>
+    <a href="#contm_p2s"></a>.</p>
 
     <section>
      <h5 id="contm_container_constructor">Container Markup for Constructor Symbols</h5>
 
-     <p>The arguments to container elements corresponding to
-     constructors may either be explicitly given as a sequence of child
-     elements, or they may be specified by a rule using qualifiers. The
-     only exceptions are the <code class="element">piecewise</code>, <code class="element">piece</code>, and
-     <code class="element">otherwise</code> elements used for representing functions with
-     <a class="intref" href="#contm_piecewise">piecewise</a> definitions.  The
-     arguments of these elements must always be specified
-     explicitly.</p>
+     <p>The arguments to container elements that correspond to
+     constructors may be explicitly given as a sequence of child
+     elements, or implicitly given by a rule using qualifiers. The
+     exceptions are the <code class="element">interval</code>, <code class="element">piecewise</code>, <code class="element">piece</code>, and
+     <code class="element">otherwise</code> elements.  The
+     arguments of these elements must be specified explicitly.</p>
 
      <div class="strict-mathml-example" id="contm_strict-set">
 
@@ -3854,20 +3843,9 @@
      </p>
 
 
-     <p>The <code class="element">set</code> element represents a function which constructs
-     mathematical sets from its arguments. It is an n-ary function. The
-     members of the set to be constructed may be given explicitly as
-     child elements of the constructor, or specified by rule as described
-     in <a href="#contm_container_constructor"></a>.  There is no implied ordering to
-     the elements of a set.</p>
+     <p>The <code class="element">set</code> element represents the n-ary function which constructs a mathematical set from its arguments. The <code class="element">set</code> element takes the attribute <code class="attribute">type</code> which may have the values <code class="attributevalue">set</code> and <code class="attributevalue">multiset</code>. The members of the set to be constructed may be given explicitly as child elements of the constructor, or specified by rule as described in <a href="#contm_container_constructor"></a>.  There is no implied ordering to the elements of a set.</p>
 
-     
-     
-     <p>The <code class="element">list</code> element represents the n-ary function which
-     constructs a list from its arguments. Lists differ from sets in that
-     there is an explicit order to the elements.
-     The list entries and order may be given explicitly or specified by rule as described
-     in <a href="#contm_container_constructor"></a>.</p>
+     <p>The <code class="element">list</code> element represents the n-ary function which constructs a list from its arguments. Lists differ from sets in that there is an explicit order to the elements. The <code class="element">list</code> element takes the attribute <code class="attribute">order</code> which may have the values <code class="attributevalue">numeric</code> and <code class="attributevalue">lexicographic</code>. The list entries and order may be given explicitly or specified by rule as described in <a href="#contm_container_constructor"></a>.</p>
 
      <section class="fold">
       <h6 id="set.ex1">Examples (Explicit elements)</h6>
@@ -4792,8 +4770,8 @@
      mathematical statements such as <q>As x tends to y,</q> and to provide a
      building block to construct more general kinds of limits.</p>
 
-     <p>The <code class="element">tendsto</code> element takes the attributes <code class="attribute">type</code> to set the
-     direction from which the limiting value is approached.</p>
+     <p>The <code class="element">tendsto</code> element takes the attribute <code class="attribute">type</code> to set the
+     direction from which the limiting value is approached. It may have any value, but common values include <code class="attributevalue">above</code> and <code class="attributevalue">below</code>.</p>
 
      <section class="fold">
       <h6 id="limit1.tendsto.ex1">Examples</h6>
@@ -7143,9 +7121,8 @@ infinity (&#x221e;).</p>
       <a class="intref" href="#parsing_interval.class">Schema Class</a>
      </p>
 
-     <p>The <code class="element">interval</code> element is a container element used to represent simple mathematical intervals of
-     the
-     real number line.  It takes an optional attribute <code class="attribute">closure</code>, with a default value
+     <p>The <code class="element">interval</code> element is a container element used to represent simple mathematical intervals of the
+     real number line.  It takes an optional attribute <code class="attribute">closure</code>, which can take any of the values <code class="attributevalue">open</code>, <code class="attributevalue">closed</code>, <code class="attributevalue">open-closed</code>, or <code class="attributevalue">closed-open</code>, with a default value
      of <code class="attributevalue">closed</code>.</p>
 
      <section class="fold">

--- a/src/contm-ops.html
+++ b/src/contm-ops.html
@@ -1,19 +1,124 @@
 <section>
- <h3 id="contm_cops">The Content MathML Operators</h3>
- <p>The following table summarizes the key information about each of the
+ <h3 id="contm_ops_syntax">The Content MathML Operators</h3>
+ <p>The following tables summarize key syntax information about the
  Content MathML operator elements.</p>
+
+ <section>
+ <h4 id="contm_constructors">The Content MathML Constructors</h4>
+
+ <p>The following table gives the child element syntax for container
+ elements that correspond to constructor symbols.  See
+<a href="#contm_container"></a> for details and examples.</p>
+
+ <p>The <b>Name</b> of the element is in the first column, and provides a link to the section that describes the constructor.</p>
+
+ <p>The <b>Content</b> column gives the child elements that may be contained within the constructor.</p>
+
+ <table id="contm_constr_table" class="syntax data">
+  <thead>
+   <tr>
+   <th>Name</th>
+   <th>Content</th>
+   </tr>
+  </thead>
+  <tbody>
+   <tr>
+    <td><a href="#contm_set">set</a></td>
+    <td><code class="parsing_ref">ContExp</code>*</td>
+   </tr>
+   <tr>
+    <td><a href="#contm_list">list</a></td>
+    <td><code class="parsing_ref">ContExp</code>*</td>
+   </tr>
+   <tr>
+    <td><a href="#contm_vector">vector</a></td>
+    <td><code class="parsing_ref">ContExp</code>*</td>
+   </tr>
+   <tr>
+    <td><a href="#contm_matrix">matrix</a></td>
+    <td><code class="parsing_ref">ContExp</code>*</td>
+   </tr>
+   <tr>
+    <td><a href="#contm_matrixrow">matrixrow</a></td>
+    <td><code class="parsing_ref">ContExp</code>*</td>
+   </tr>
+   <tr>
+    <td><a href="#contm_lambda">lambda</a></td>
+    <td><code class="parsing_ref">ContExp</code></td>
+   </tr>
+   <tr>
+    <td><a href="#contm_interval_constructor">interval</a></td>
+    <td><code class="parsing_ref">ContExp</code>,<code class="parsing_ref">ContExp</code></td>
+   </tr>
+   <tr>
+    <td><a href="#contm_piecewise">piecewise</a></td>
+    <td><code class="parsing_ref">piece</code>*,
+    <code class="parsing_ref">otherwise</code>?</td>
+   </tr>
+   <tr>
+    <td><a href="#contm_piecewise">piece</a></td>
+    <td><code class="parsing_ref">ContExp</code>,<code class="parsing_ref">ContExp</code></td>
+   </tr>
+   <tr>
+    <td><a href="#contm_piecewise">otherwise</a></td>
+    <td><code class="parsing_ref">ContExp</code></td>
+   </tr>
+  </tbody>
+ </table>
+ </section>
+
+ <section>
+ <h4 id="contm_atts">The Content MathML Attributes</h4>
+
+  <p>The following table lists the attributes that may be supplied on specific operator elements.  In addition, all operator elements allow the <a class="intref" href="#parsing_CommonAtt"><code class="parsing_ref">CommonAtt</code></a> and <a class="intref" href="#parsing_DefEncAtt"><code class="parsing_ref">DefEncAtt</code></a> attributes.</p>
+
+ <p>The <b>Name</b> of the element is in the first column, and provides a link to the section that describes the operator.</p>
+
+ <p>The <b>Attribute</b> column specifies the name of the attribute that may be supplied on the operator element.</p>
+
+ <p>The <b>Values</b> column specifies the values that may be supplied for the attribute specific to the operator element.</p>
+
+ <table id="contm_atts_table" class="syntax data">
+  <thead>
+   <tr>
+   <th>Name</th>
+   <th>Attribute</th>
+   <th>Values</th>
+   </tr>
+  </thead>
+  <tbody>
+   <tr>
+    <td><a href="#contm_tendsto">tendsto</a></td>
+    <td><code class="parsing_ref">type</code>?</td>
+    <td>string</td>
+   </tr>
+   <tr>
+    <td><a href="#contm_interval_constructor">interval</a></td>
+    <td><code class="parsing_ref">closure</code>?</td>
+    <td><code class="attributevalue">open</code> | <code class="attributevalue">closed</code> | <code class="attributevalue">open-closed</code> | <code class="attributevalue">closed-open</code></td>
+   </tr>
+   <tr>
+    <td><a href="#contm_set">set</a></td>
+    <td><code class="parsing_ref">type</code>?</td>
+    <td><code class="attributevalue">set</code> | <code class="attributevalue">multiset</code> | text </td>
+   </tr>
+   <tr>
+    <td><a href="#contm_list">list</a></td>
+    <td><code class="parsing_ref">order</code></td>
+    <td><code class="attributevalue">numeric</code> | <code class="attributevalue">lexicographic</code></td>
+   </tr>
+  </tbody>
+ </table>
+ </section>
+
+ <section>
+ <h4 id="contm_ops">The Content MathML Operators</h4>
 
  <p>The <b>Name</b> of the element is in the first column, and provides a link to the section that describes the operator.</p>
 
  <p>The <b>Symbol(s)</b> column provides a list of <code class="element">csymbol</code>s that may be used to encode the operator, with links to the OpenMath symbols used in the <a href="#contm_p2s">Strict Content MathML Transformation Algorithm</a>.</p>
 
  <p>The <b>Class</b> column specifies the operator class, which indicates how many arguments the operator expects, and may determine the mapping to Strict Content MathML, as described in <a href="#contm_opclasses"></a>.</p>
-
- <p>The <b>Attributes</b> column specifies the attributes that may be supplied on the operator element.  All operator elements allow the <code class="parsing_ref">CommonAtt</code> and <code class="parsing_ref">DefEncAtt</code> attributes, and so these are not explicitly listed in the table below.</p>
-
- <p>The <b>Values</b> column specifies the values that may be supplied for the attribues specific to each operator element.</p>
-
- <p>The <b>Content</b> column specifies the child elements that may be contained within the (container) operator element.  Since most operator elements are empty elements, this fact is not listed in the table below.</p>
 
  <p>The <b>Qualifiers</b> column lists the qualifier elements accepted by the operator, either as child elements (for container elements) or as following sibling elements (for empty operator elements).</p>
 
@@ -23,9 +128,6 @@
    <th>Name</th>
    <th>Symbol(s)</th>
    <th>Class</th>
-   <th>Attributes</th>
-   <th>Values</th>
-   <th>Content</th>
    <th>Qualifiers</th>
    </tr>
   </thead>
@@ -34,36 +136,24 @@
     <td><a href="#contm_plus">plus</a></td>
     <td><a class="omsymbol" href="https://openmath.org/cd/arith1#plus">plus</a></td>
     <td><a class="intref" href="#contm_nary_arith">nary-arith</a></td>
-    <td></td>
-    <td></td>
-    <td></td>
     <td><code class="parsing_ref">BvarQ</code>,<code class="parsing_ref">DomainQ</code></td>
    </tr>
    <tr>
     <td><a href="#contm_times">times</a></td>
     <td><a class="omsymbol" href="https://openmath.org/cd/arith1#times">times</a></td>
     <td><a class="intref" href="#contm_nary_arith">nary-arith</a></td>
-    <td></td>
-    <td></td>
-    <td></td>
     <td><code class="parsing_ref">BvarQ</code>,<code class="parsing_ref">DomainQ</code></td>
    </tr>
    <tr>
     <td><a href="#contm_gcd">gcd</a></td>
     <td><a class="omsymbol" href="https://openmath.org/cd/arith1#gcd">gcd</a></td>
     <td><a class="intref" href="#contm_nary_arith">nary-arith</a></td>
-    <td></td>
-    <td></td>
-    <td></td>
     <td><code class="parsing_ref">BvarQ</code>,<code class="parsing_ref">DomainQ</code></td>
    </tr>
    <tr>
     <td><a href="#contm_lcm">lcm</a></td>
     <td><a class="omsymbol" href="https://openmath.org/cd/arith1#lcm">lcm</a></td>
     <td><a class="intref" href="#contm_nary_arith">nary-arith</a></td>
-    <td></td>
-    <td></td>
-    <td></td>
     <td><code class="parsing_ref">BvarQ</code>,<code class="parsing_ref">DomainQ</code></td>
    </tr>
   </tbody>
@@ -72,9 +162,6 @@
     <td><a href="#contm_compose">compose</a></td>
     <td><a class="omsymbol" href="https://openmath.org/cd/fns1#left_compose">left_compose</a></td>
     <td><a class="intref" href="#contm_nary_functional">nary-functional</a></td>
-    <td></td>
-    <td></td>
-    <td></td>
     <td><code class="parsing_ref">BvarQ</code>,<code class="parsing_ref">DomainQ</code></td>
    </tr>
   </tbody>
@@ -83,27 +170,18 @@
     <td><a href="#contm_and">and</a></td>
     <td><a class="omsymbol" href="https://openmath.org/cd/logic1#and">and</a></td>
     <td><a class="intref" href="#contm_nary_logical">nary-logical</a></td>
-    <td></td>
-    <td></td>
-    <td></td>
     <td><code class="parsing_ref">BvarQ</code>,<code class="parsing_ref">DomainQ</code></td>
    </tr>
    <tr>
     <td><a href="#contm_or">or</a></td>
     <td><a class="omsymbol" href="https://openmath.org/cd/logic1#or">or</a></td>
     <td><a class="intref" href="#contm_nary_logical">nary-logical</a></td>
-    <td></td>
-    <td></td>
-    <td></td>
     <td><code class="parsing_ref">BvarQ</code>,<code class="parsing_ref">DomainQ</code></td>
    </tr>
    <tr>
     <td><a href="#contm_xor">xor</a></td>
     <td><a class="omsymbol" href="https://openmath.org/cd/logic1#xor">xor</a></td>
     <td><a class="intref" href="#contm_nary_logical">nary-logical</a></td>
-    <td></td>
-    <td></td>
-    <td></td>
     <td><code class="parsing_ref">BvarQ</code>,<code class="parsing_ref">DomainQ</code></td>
    </tr>
   </tbody>
@@ -114,9 +192,6 @@
     <a class="omsymbol" href="https://openmath.org/cd/linalg1#matrix_selector">matrix_selector</a></td>
     <td><a class="intref" href="#contm_nary_linalg">nary-linalg</a></td>
     <td></td>
-    <td></td>
-    <td></td>
-    <td></td>
    </tr>
   </tbody>
   <tbody id="cops_nary_set">
@@ -124,27 +199,18 @@
     <td><a href="#contm_union">union</a></td>
     <td><a class="omsymbol" href="https://openmath.org/cd/set1#union">union</a></td>
     <td><a class="intref" href="#contm_nary_set">nary-set</a></td>
-    <td></td>
-    <td></td>
-    <td></td>
     <td><code class="parsing_ref">BvarQ</code>,<code class="parsing_ref">DomainQ</code></td>
    </tr>
    <tr>
     <td><a href="#contm_intersect">intersect</a></td>
     <td><a class="omsymbol" href="https://openmath.org/cd/set1#intersect">intersect</a></td>
     <td><a class="intref" href="#contm_nary_set">nary-set</a></td>
-    <td></td>
-    <td></td>
-    <td></td>
     <td><code class="parsing_ref">BvarQ</code>,<code class="parsing_ref">DomainQ</code></td>
    </tr>
    <tr>
     <td><a href="#contm_cartesianproduct">cartesianproduct</a></td>
     <td><a class="omsymbol" href="https://openmath.org/cd/set1#cartesian_product">cartesian_product</a></td>
     <td><a class="intref" href="#contm_nary_set">nary-set</a></td>
-    <td></td>
-    <td></td>
-    <td></td>
     <td><code class="parsing_ref">BvarQ</code>,<code class="parsing_ref">DomainQ</code></td>
    </tr>
   </tbody>
@@ -155,9 +221,6 @@
      <a class="omsymbol" href="https://openmath.org/cd/linalg2#vector">vector</a>
     </td>
     <td><a class="intref" href="#contm_nary_construct_matrix">nary-constructor</a></td>
-    <td></td>
-    <td></td>
-    <td><code class="parsing_ref">ContExp</code>*</td>
     <td><code class="parsing_ref">BvarQ</code>,<code class="parsing_ref">DomainQ</code></td>
    </tr>
    <tr>
@@ -166,9 +229,6 @@
      <a class="omsymbol" href="https://openmath.org/cd/linalg2#matrix">matrix</a>
     </td>
     <td><a class="intref" href="#contm_nary_construct_matrix">nary-constructor</a></td>
-    <td></td>
-    <td></td>
-    <td><code class="parsing_ref">ContExp</code>*</td>
     <td><code class="parsing_ref">BvarQ</code>,<code class="parsing_ref">DomainQ</code></td>
    </tr>
    <tr>
@@ -177,9 +237,6 @@
      <a class="omsymbol" href="https://openmath.org/cd/linalg2#matrixrow">matrixrow</a>
     </td>
     <td><a class="intref" href="#contm_nary_construct_matrix">nary-constructor</a></td>
-    <td></td>
-    <td></td>
-    <td><code class="parsing_ref">ContExp</code>*</td>
     <td><code class="parsing_ref">BvarQ</code>,<code class="parsing_ref">DomainQ</code></td>
    </tr>
   </tbody>
@@ -188,45 +245,30 @@
     <td><a href="#contm_eq">eq</a></td>
     <td><a class="omsymbol" href="https://openmath.org/cd/relation1#eq">eq</a></td>
     <td><a class="intref" href="#contm_nary_reln">nary-reln</a></td>
-    <td></td>
-    <td></td>
-    <td></td>
     <td><code class="parsing_ref">BvarQ</code>,<code class="parsing_ref">DomainQ</code></td>
    </tr>
    <tr>
     <td><a href="#contm_gt">gt</a></td>
     <td><a class="omsymbol" href="https://openmath.org/cd/relation1#gt">gt</a></td>
     <td><a class="intref" href="#contm_nary_reln">nary-reln</a></td>
-    <td></td>
-    <td></td>
-    <td></td>
     <td><code class="parsing_ref">BvarQ</code>,<code class="parsing_ref">DomainQ</code></td>
    </tr>
    <tr>
     <td><a href="#contm_lt">lt</a></td>
     <td><a class="omsymbol" href="https://openmath.org/cd/relation1#lt">lt</a></td>
     <td><a class="intref" href="#contm_nary_reln">nary-reln</a></td>
-    <td></td>
-    <td></td>
-    <td></td>
     <td><code class="parsing_ref">BvarQ</code>,<code class="parsing_ref">DomainQ</code></td>
    </tr>
    <tr>
     <td><a href="#contm_geq">geq</a></td>
     <td><a class="omsymbol" href="https://openmath.org/cd/relation1#geq">geq</a></td>
     <td><a class="intref" href="#contm_nary_reln">nary-reln</a></td>
-    <td></td>
-    <td></td>
-    <td></td>
     <td><code class="parsing_ref">BvarQ</code>,<code class="parsing_ref">DomainQ</code></td>
    </tr>
    <tr>
     <td><a href="#contm_leq">leq</a></td>
     <td><a class="omsymbol" href="https://openmath.org/cd/relation1#leq">leq</a></td>
     <td><a class="intref" href="#contm_nary_reln">nary-reln</a></td>
-    <td></td>
-    <td></td>
-    <td></td>
     <td><code class="parsing_ref">BvarQ</code>,<code class="parsing_ref">DomainQ</code></td>
    </tr>
   </tbody>
@@ -236,17 +278,11 @@
     <td><a class="omsymbol" href="https://openmath.org/cd/set1#subset">subset</a></td>
     <td><a class="intref" href="#contm_nary_reln">nary-set-reln</a></td>
     <td></td>
-    <td></td>
-    <td></td>
-    <td></td>
    </tr>
    <tr>
     <td><a href="#contm_prsubset">prsubset</a></td>
     <td><a class="omsymbol" href="https://openmath.org/cd/set1#prsubset">prsubset</a></td>
     <td><a class="intref" href="#contm_nary_reln">nary-set-reln</a></td>
-    <td></td>
-    <td></td>
-    <td></td>
     <td></td>
    </tr>
   </tbody>
@@ -255,18 +291,12 @@
     <td><a href="#contm_max">max</a></td>
     <td><a class="omsymbol" href="https://openmath.org/cd/minmax1#max">max</a></td>
     <td><a class="intref" href="#contm_nary_unary_minmax">nary-minmax</a></td>
-    <td></td>
-    <td></td>
-    <td></td>
     <td><code class="parsing_ref">BvarQ</code>,<code class="parsing_ref">DomainQ</code></td>
    </tr>
    <tr>
     <td><a href="#contm_min">min</a></td>
     <td><a class="omsymbol" href="https://openmath.org/cd/minmax1#min">min</a></td>
     <td><a class="intref" href="#contm_nary_unary_minmax">nary-minmax</a></td>
-    <td></td>
-    <td></td>
-    <td></td>
     <td><code class="parsing_ref">BvarQ</code>,<code class="parsing_ref">DomainQ</code></td>
    </tr>
   </tbody>
@@ -275,45 +305,30 @@
     <td><a href="#contm_mean">mean</a></td>
     <td><a class="omsymbol" href="https://openmath.org/cd/s_dist1#mean">mean</a>, <a class="omsymbol" href="https://openmath.org/cd/s_data1#mean">mean</a></td>
     <td><a class="intref" href="#contm_nary_unary_stats">nary-stats</a></td>
-    <td></td>
-    <td></td>
-    <td></td>
     <td><code class="parsing_ref">BvarQ</code>,<code class="parsing_ref">DomainQ</code></td>
    </tr>
    <tr>
     <td><a href="#contm_sdev">sdev</a></td>
     <td><a class="omsymbol" href="https://openmath.org/cd/s_dist1#sdev">sdev</a>, <a class="omsymbol" href="https://openmath.org/cd/s_data1#sdev">sdev</a></td>
     <td><a class="intref" href="#contm_nary_unary_stats">nary-stats</a></td>
-    <td></td>
-    <td></td>
-    <td></td>
     <td><code class="parsing_ref">BvarQ</code>,<code class="parsing_ref">DomainQ</code></td>
    </tr>
    <tr>
     <td><a href="#contm_variance">variance</a></td>
     <td><a class="omsymbol" href="https://openmath.org/cd/s_dist1#variance">variance</a>, <a class="omsymbol" href="https://openmath.org/cd/s_data1#variance">variance</a></td>
     <td><a class="intref" href="#contm_nary_unary_stats">nary-stats</a></td>
-    <td></td>
-    <td></td>
-    <td></td>
     <td><code class="parsing_ref">BvarQ</code>,<code class="parsing_ref">DomainQ</code></td>
    </tr>
    <tr>
     <td><a href="#contm_median">median</a></td>
     <td><a class="omsymbol" href="https://openmath.org/cd/s_data1#median">median</a></td>
     <td><a class="intref" href="#contm_nary_unary_stats">nary-stats</a></td>
-    <td></td>
-    <td></td>
-    <td></td>
     <td><code class="parsing_ref">BvarQ</code>,<code class="parsing_ref">DomainQ</code></td>
    </tr>
    <tr>
     <td><a href="#contm_mode">mode</a></td>
     <td><a class="omsymbol" href="https://openmath.org/cd/s_data1#mode">mode</a></td>
     <td><a class="intref" href="#contm_nary_unary_stats">nary-stats</a></td>
-    <td></td>
-    <td></td>
-    <td></td>
     <td><code class="parsing_ref">BvarQ</code>,<code class="parsing_ref">DomainQ</code></td>
    </tr>
   </tbody>
@@ -323,17 +338,11 @@
     <td><a class="omsymbol" href="https://openmath.org/cd/integer1#quotient">quotient</a></td>
     <td><a class="intref" href="#contm_binary_arith">binary-arith</a></td>
     <td></td>
-    <td></td>
-    <td></td>
-    <td></td>
    </tr>
    <tr>
     <td><a href="#contm_divide">divide</a></td>
     <td><a class="omsymbol" href="https://openmath.org/cd/arith1#divide">divide</a></td>
     <td><a class="intref" href="#contm_binary_arith">binary-arith</a></td>
-    <td></td>
-    <td></td>
-    <td></td>
     <td></td>
    </tr>
    <tr>
@@ -341,17 +350,11 @@
     <td><a class="omsymbol" href="https://openmath.org/cd/arith1#unary_minus">unary_minus</a>, <a class="omsymbol" href="https://openmath.org/cd/arith1#minus">minus</a></td>
     <td><a class="intref" href="#contm_unary_arith">unary-arith</a>, <a class="intref" href="#contm_binary_arith">binary-arith</a></td>
     <td></td>
-    <td></td>
-    <td></td>
-    <td></td>
    </tr>
    <tr>
     <td><a href="#contm_power">power</a></td>
     <td><a class="omsymbol" href="https://openmath.org/cd/arith1#power">power</a></td>
     <td><a class="intref" href="#contm_binary_arith">binary-arith</a></td>
-    <td></td>
-    <td></td>
-    <td></td>
     <td></td>
    </tr>
    <tr>
@@ -359,17 +362,11 @@
     <td><a class="omsymbol" href="https://openmath.org/cd/integer1#remainder">remainder</a></td>
     <td><a class="intref" href="#contm_binary_arith">binary-arith</a></td>
     <td></td>
-    <td></td>
-    <td></td>
-    <td></td>
    </tr>
    <tr>
     <td><a href="#contm_root_unary">root</a> <a href="#contm_root_binary">root</a></td>
     <td><a class="omsymbol" href="https://openmath.org/cd/arith1#root">root</a></td>
     <td><a class="intref" href="#contm_unary_arith">unary-arith</a>, <a class="intref" href="#contm_binary_arith">binary-arith</a></td>
-    <td></td>
-    <td></td>
-    <td></td>
     <td><code class="parsing_ref">degree</code></td>
    </tr>
   </tbody>
@@ -379,17 +376,11 @@
     <td><a class="omsymbol" href="https://openmath.org/cd/logic1#implies">implies</a></td>
     <td><a class="intref" href="#contm_binary_logical">binary-logical</a></td>
     <td></td>
-    <td></td>
-    <td></td>
-    <td></td>
    </tr>
    <tr>
     <td><a href="#contm_equivalent">equivalent</a></td>
     <td><a class="omsymbol" href="https://openmath.org/cd/logic1#equivalent">equivalent</a></td>
     <td><a class="intref" href="#contm_binary_logical">binary-logical</a></td>
-    <td></td>
-    <td></td>
-    <td></td>
     <td><code class="parsing_ref">BvarQ</code>,<code class="parsing_ref">DomainQ</code></td>
    </tr>
   </tbody>
@@ -399,17 +390,11 @@
     <td><a class="omsymbol" href="https://openmath.org/cd/relation1#neq">neq</a></td>
     <td><a class="intref" href="#contm_binary_reln">binary-reln</a></td>
     <td></td>
-    <td></td>
-    <td></td>
-    <td></td>
    </tr>
    <tr>
     <td><a href="#contm_approx">approx</a></td>
     <td><a class="omsymbol" href="https://openmath.org/cd/relation1#approx">approx</a></td>
     <td><a class="intref" href="#contm_binary_reln">binary-reln</a></td>
-    <td></td>
-    <td></td>
-    <td></td>
     <td></td>
    </tr>
    <tr>
@@ -417,17 +402,11 @@
     <td><a class="omsymbol" href="https://openmath.org/cd/integer1#factorof">factorof</a></td>
     <td><a class="intref" href="#contm_binary_reln">binary-reln</a></td>
     <td></td>
-    <td></td>
-    <td></td>
-    <td></td>
    </tr>
    <tr>
     <td><a href="#contm_tendsto">tendsto</a></td>
     <td><a class="omsymbol" href="https://openmath.org/cd/limit1#limit">limit</a></td>
     <td><a class="intref" href="#contm_binary_reln">binary-reln</a></td>
-    <td><code class="parsing_ref">type</code>?</td>
-    <td>string</td>
-    <td></td>
     <td></td>
    </tr>
   </tbody>
@@ -437,26 +416,17 @@
     <td><a class="omsymbol" href="https://openmath.org/cd/linalg1#vectorproduct">vectorproduct</a></td>
     <td><a class="intref" href="#contm_binary_linalg">binary-linalg</a></td>
     <td></td>
-    <td></td>
-    <td></td>
-    <td></td>
    </tr>
    <tr>
     <td><a href="#contm_scalarproduct">scalarproduct</a></td>
     <td><a class="omsymbol" href="https://openmath.org/cd/linalg1#scalarproduct">scalarproduct</a></td>
     <td><a class="intref" href="#contm_binary_linalg">binary-linalg</a></td>
     <td></td>
-    <td></td>
-    <td></td>
-    <td></td>
    </tr>
    <tr>
     <td><a href="#contm_outerproduct">outerproduct</a></td>
     <td><a class="omsymbol" href="https://openmath.org/cd/linalg1#outerproduct">outerproduct</a></td>
     <td><a class="intref" href="#contm_binary_linalg">binary-linalg</a></td>
-    <td></td>
-    <td></td>
-    <td></td>
     <td></td>
    </tr>
   </tbody>
@@ -466,17 +436,11 @@
     <td><a class="omsymbol" href="https://openmath.org/cd/set1#in">in</a></td>
     <td><a class="intref" href="#contm_binary_set">binary-set</a></td>
     <td></td>
-    <td></td>
-    <td></td>
-    <td></td>
    </tr>
    <tr>
     <td><a href="#contm_notin">notin</a></td>
     <td><a class="omsymbol" href="https://openmath.org/cd/set1#notin">notin</a></td>
     <td><a class="intref" href="#contm_binary_set">binary-set</a></td>
-    <td></td>
-    <td></td>
-    <td></td>
     <td></td>
    </tr>
    <tr>
@@ -484,26 +448,17 @@
     <td><a class="omsymbol" href="https://openmath.org/cd/set1#notsubset">notsubset</a></td>
     <td><a class="intref" href="#contm_binary_set">binary-set</a></td>
     <td></td>
-    <td></td>
-    <td></td>
-    <td></td>
    </tr>
    <tr>
     <td><a href="#contm_notprsubset">notprsubset</a></td>
     <td><a class="omsymbol" href="https://openmath.org/cd/set1#notprsubset">notprsubset</a></td>
     <td><a class="intref" href="#contm_binary_set">binary-set</a></td>
     <td></td>
-    <td></td>
-    <td></td>
-    <td></td>
    </tr>
    <tr>
     <td><a href="#contm_setdiff">setdiff</a></td>
     <td><a class="omsymbol" href="https://openmath.org/cd/set1#setdiff">setdiff</a>, <a class="omsymbol" href="https://openmath.org/cd/multiset1#setdiff">setdiff</a></td>
     <td><a class="intref" href="#contm_binary_set">binary-set</a></td>
-    <td></td>
-    <td></td>
-    <td></td>
     <td></td>
    </tr>
   </tbody>
@@ -513,9 +468,6 @@
     <td><a class="omsymbol" href="https://openmath.org/cd/logic1#not">not</a></td>
     <td><a class="intref" href="#contm_unary_logical">unary-logical</a></td>
     <td></td>
-    <td></td>
-    <td></td>
-    <td></td>
    </tr>
   </tbody>
   <tbody id="cops_unary_arith">
@@ -524,26 +476,17 @@
     <td><a class="omsymbol" href="https://openmath.org/cd/integer1#factorial">factorial</a></td>
     <td><a class="intref" href="#contm_unary_arith">unary-arith</a></td>
     <td></td>
-    <td></td>
-    <td></td>
-    <td></td>
    </tr>
    <tr>
     <td><a href="#contm_minus_unary">minus</a> <a href="#contm_minus_binary">minus</a></td>
     <td><a class="omsymbol" href="https://openmath.org/cd/arith1#unary_minus">unary_minus</a>, <a class="omsymbol" href="https://openmath.org/cd/arith1#minus">minus</a></td>
     <td><a class="intref" href="#contm_unary_arith">unary-arith</a>, <a class="intref" href="#contm_binary_arith">binary-arith</a></td>
     <td></td>
-    <td></td>
-    <td></td>
-    <td></td>
    </tr>
    <tr>
     <td><a href="#contm_root_unary">root</a> <a href="#contm_root_binary">root</a></td>
     <td><a class="omsymbol" href="https://openmath.org/cd/arith1#root">root</a></td>
     <td><a class="intref" href="#contm_unary_arith">unary-arith</a>, <a class="intref" href="#contm_binary_arith">binary-arith</a></td>
-    <td></td>
-    <td></td>
-    <td></td>
     <td><code class="parsing_ref">degree</code></td>
    </tr>
    <tr>
@@ -551,17 +494,11 @@
     <td><a class="omsymbol" href="https://openmath.org/cd/arith1#abs">abs</a></td>
     <td><a class="intref" href="#contm_unary_arith">unary-arith</a></td>
     <td></td>
-    <td></td>
-    <td></td>
-    <td></td>
    </tr>
    <tr>
     <td><a href="#contm_conjugate">conjugate</a></td>
     <td><a class="omsymbol" href="https://openmath.org/cd/complex1#conjugate">conjugate</a></td>
     <td><a class="intref" href="#contm_unary_arith">unary-arith</a></td>
-    <td></td>
-    <td></td>
-    <td></td>
     <td></td>
    </tr>
    <tr>
@@ -569,17 +506,11 @@
     <td><a class="omsymbol" href="https://openmath.org/cd/complex1#argument">argument</a></td>
     <td><a class="intref" href="#contm_unary_arith">unary-arith</a></td>
     <td></td>
-    <td></td>
-    <td></td>
-    <td></td>
    </tr>
    <tr>
     <td><a href="#contm_real">real</a></td>
     <td><a class="omsymbol" href="https://openmath.org/cd/complex1#real">real</a></td>
     <td><a class="intref" href="#contm_unary_arith">unary-arith</a></td>
-    <td></td>
-    <td></td>
-    <td></td>
     <td></td>
    </tr>
    <tr>
@@ -587,17 +518,11 @@
     <td><a class="omsymbol" href="https://openmath.org/cd/complex1#imaginary">imaginary</a></td>
     <td><a class="intref" href="#contm_unary_arith">unary-arith</a></td>
     <td></td>
-    <td></td>
-    <td></td>
-    <td></td>
    </tr>
    <tr>
     <td><a href="#contm_floor">floor</a></td>
     <td><a class="omsymbol" href="https://openmath.org/cd/rounding1#floor">floor</a></td>
     <td><a class="intref" href="#contm_unary_arith">unary-arith</a></td>
-    <td></td>
-    <td></td>
-    <td></td>
     <td></td>
    </tr>
    <tr>
@@ -605,17 +530,11 @@
     <td><a class="omsymbol" href="https://openmath.org/cd/rounding1#ceiling">ceiling</a></td>
     <td><a class="intref" href="#contm_unary_arith">unary-arith</a></td>
     <td></td>
-    <td></td>
-    <td></td>
-    <td></td>
    </tr>
    <tr>
     <td><a href="#contm_exp">exp</a></td>
     <td><a class="omsymbol" href="https://openmath.org/cd/transc1#exp">exp</a></td>
     <td><a class="intref" href="#contm_unary_arith">unary-arith</a></td>
-    <td></td>
-    <td></td>
-    <td></td>
     <td></td>
    </tr>
   </tbody>
@@ -625,17 +544,11 @@
     <td><a class="omsymbol" href="https://openmath.org/cd/linalg1#determinant">determinant</a></td>
     <td><a class="intref" href="#contm_unary_linalg">unary-linalg</a></td>
     <td></td>
-    <td></td>
-    <td></td>
-    <td></td>
    </tr>
    <tr>
     <td><a href="#contm_transpose">transpose</a></td>
     <td><a class="omsymbol" href="https://openmath.org/cd/linalg1#transpose">transpose</a></td>
     <td><a class="intref" href="#contm_unary_linalg">unary-linalg</a></td>
-    <td></td>
-    <td></td>
-    <td></td>
     <td></td>
    </tr>
   </tbody>
@@ -645,17 +558,11 @@
     <td><a class="omsymbol" href="https://openmath.org/cd/fns1#inverse">inverse</a></td>
     <td><a class="intref" href="#contm_unary_functional">unary-functional</a></td>
     <td></td>
-    <td></td>
-    <td></td>
-    <td></td>
    </tr>
    <tr>
     <td><a href="#contm_ident">ident</a></td>
     <td><a class="omsymbol" href="https://openmath.org/cd/fns1#identity">identity</a></td>
     <td><a class="intref" href="#contm_unary_functional">unary-functional</a></td>
-    <td></td>
-    <td></td>
-    <td></td>
     <td></td>
    </tr>
    <tr>
@@ -663,17 +570,11 @@
     <td><a class="omsymbol" href="https://openmath.org/cd/fns1#domain">domain</a></td>
     <td><a class="intref" href="#contm_unary_functional">unary-functional</a></td>
     <td></td>
-    <td></td>
-    <td></td>
-    <td></td>
    </tr>
    <tr>
     <td><a href="#contm_codomain">codomain</a></td>
     <td><a class="omsymbol" href="https://openmath.org/cd/fns1#range">range</a></td>
     <td><a class="intref" href="#contm_unary_functional">unary-functional</a></td>
-    <td></td>
-    <td></td>
-    <td></td>
     <td></td>
    </tr>
    <tr>
@@ -681,17 +582,11 @@
     <td><a class="omsymbol" href="https://openmath.org/cd/fns1#image">image</a></td>
     <td><a class="intref" href="#contm_unary_functional">unary-functional</a></td>
     <td></td>
-    <td></td>
-    <td></td>
-    <td></td>
    </tr>
    <tr>
     <td><a href="#contm_ln">ln</a></td>
     <td><a class="omsymbol" href="https://openmath.org/cd/transc1#ln">ln</a></td>
     <td><a class="intref" href="#contm_unary_functional">unary-functional</a></td>
-    <td></td>
-    <td></td>
-    <td></td>
     <td></td>
    </tr>
   </tbody>
@@ -701,9 +596,6 @@
     <td><a class="omsymbol" href="https://openmath.org/cd/set1#size">size</a>, <a class="omsymbol" href="https://openmath.org/cd/multiset1#size">size</a></td>
     <td><a class="intref" href="#contm_unary_set">unary-set</a></td>
     <td></td>
-    <td></td>
-    <td></td>
-    <td></td>
    </tr>
   </tbody>
   <tbody id="cops_unary_elementary">
@@ -712,17 +604,11 @@
     <td><a class="omsymbol" href="https://openmath.org/cd/transc1#sin">sin</a></td>
     <td><a class="intref" href="#contm_unary_elementary">unary-elementary</a></td>
     <td></td>
-    <td></td>
-    <td></td>
-    <td></td>
    </tr>
    <tr>
     <td><a href="#contm_cos">cos</a></td>
     <td><a class="omsymbol" href="https://openmath.org/cd/transc1#cos">cos</a></td>
     <td><a class="intref" href="#contm_unary_elementary">unary-elementary</a></td>
-    <td></td>
-    <td></td>
-    <td></td>
     <td></td>
    </tr>
    <tr>
@@ -730,17 +616,11 @@
     <td><a class="omsymbol" href="https://openmath.org/cd/transc1#tan">tan</a></td>
     <td><a class="intref" href="#contm_unary_elementary">unary-elementary</a></td>
     <td></td>
-    <td></td>
-    <td></td>
-    <td></td>
    </tr>
    <tr>
     <td><a href="#contm_sec">sec</a></td>
     <td><a class="omsymbol" href="https://openmath.org/cd/transc1#sec">sec</a></td>
     <td><a class="intref" href="#contm_unary_elementary">unary-elementary</a></td>
-    <td></td>
-    <td></td>
-    <td></td>
     <td></td>
    </tr>
    <tr>
@@ -748,17 +628,11 @@
     <td><a class="omsymbol" href="https://openmath.org/cd/transc1#csc">csc</a></td>
     <td><a class="intref" href="#contm_unary_elementary">unary-elementary</a></td>
     <td></td>
-    <td></td>
-    <td></td>
-    <td></td>
    </tr>
    <tr>
     <td><a href="#contm_cot">cot</a></td>
     <td><a class="omsymbol" href="https://openmath.org/cd/transc1#cot">cot</a></td>
     <td><a class="intref" href="#contm_unary_elementary">unary-elementary</a></td>
-    <td></td>
-    <td></td>
-    <td></td>
     <td></td>
    </tr>
    <tr>
@@ -766,17 +640,11 @@
     <td><a class="omsymbol" href="https://openmath.org/cd/transc1#arcsin">arcsin</a></td>
     <td><a class="intref" href="#contm_unary_elementary">unary-elementary</a></td>
     <td></td>
-    <td></td>
-    <td></td>
-    <td></td>
    </tr>
    <tr>
     <td><a href="#contm_arccos">arccos</a></td>
     <td><a class="omsymbol" href="https://openmath.org/cd/transc1#arccos">arccos</a></td>
     <td><a class="intref" href="#contm_unary_elementary">unary-elementary</a></td>
-    <td></td>
-    <td></td>
-    <td></td>
     <td></td>
    </tr>
    <tr>
@@ -784,17 +652,11 @@
     <td><a class="omsymbol" href="https://openmath.org/cd/transc1#arctan">arctan</a></td>
     <td><a class="intref" href="#contm_unary_elementary">unary-elementary</a></td>
     <td></td>
-    <td></td>
-    <td></td>
-    <td></td>
    </tr>
    <tr>
     <td><a href="#contm_arcsec">arcsec</a></td>
     <td><a class="omsymbol" href="https://openmath.org/cd/transc1#arcsec">arcsec</a></td>
     <td><a class="intref" href="#contm_unary_elementary">unary-elementary</a></td>
-    <td></td>
-    <td></td>
-    <td></td>
     <td></td>
    </tr>
    <tr>
@@ -802,17 +664,11 @@
     <td><a class="omsymbol" href="https://openmath.org/cd/transc1#arccsc">arccsc</a></td>
     <td><a class="intref" href="#contm_unary_elementary">unary-elementary</a></td>
     <td></td>
-    <td></td>
-    <td></td>
-    <td></td>
    </tr>
    <tr>
     <td><a href="#contm_arccot">arccot</a></td>
     <td><a class="omsymbol" href="https://openmath.org/cd/transc1#arccot">arccot</a></td>
     <td><a class="intref" href="#contm_unary_elementary">unary-elementary</a></td>
-    <td></td>
-    <td></td>
-    <td></td>
     <td></td>
    </tr>
    <tr>
@@ -820,17 +676,11 @@
     <td><a class="omsymbol" href="https://openmath.org/cd/transc1#sinh">sinh</a></td>
     <td><a class="intref" href="#contm_unary_elementary">unary-elementary</a></td>
     <td></td>
-    <td></td>
-    <td></td>
-    <td></td>
    </tr>
    <tr>
     <td><a href="#contm_cosh">cosh</a></td>
     <td><a class="omsymbol" href="https://openmath.org/cd/transc1#cosh">cosh</a></td>
     <td><a class="intref" href="#contm_unary_elementary">unary-elementary</a></td>
-    <td></td>
-    <td></td>
-    <td></td>
     <td></td>
    </tr>
    <tr>
@@ -838,17 +688,11 @@
     <td><a class="omsymbol" href="https://openmath.org/cd/transc1#tanh">tanh</a></td>
     <td><a class="intref" href="#contm_unary_elementary">unary-elementary</a></td>
     <td></td>
-    <td></td>
-    <td></td>
-    <td></td>
    </tr>
    <tr>
     <td><a href="#contm_sech">sech</a></td>
     <td><a class="omsymbol" href="https://openmath.org/cd/transc1#sech">sech</a></td>
     <td><a class="intref" href="#contm_unary_elementary">unary-elementary</a></td>
-    <td></td>
-    <td></td>
-    <td></td>
     <td></td>
    </tr>
    <tr>
@@ -856,17 +700,11 @@
     <td><a class="omsymbol" href="https://openmath.org/cd/transc1#csch">csch</a></td>
     <td><a class="intref" href="#contm_unary_elementary">unary-elementary</a></td>
     <td></td>
-    <td></td>
-    <td></td>
-    <td></td>
    </tr>
    <tr>
     <td><a href="#contm_coth">coth</a></td>
     <td><a class="omsymbol" href="https://openmath.org/cd/transc1#coth">coth</a></td>
     <td><a class="intref" href="#contm_unary_elementary">unary-elementary</a></td>
-    <td></td>
-    <td></td>
-    <td></td>
     <td></td>
    </tr>
    <tr>
@@ -874,17 +712,11 @@
     <td><a class="omsymbol" href="https://openmath.org/cd/transc1#arcsinh">arcsinh</a></td>
     <td><a class="intref" href="#contm_unary_elementary">unary-elementary</a></td>
     <td></td>
-    <td></td>
-    <td></td>
-    <td></td>
    </tr>
    <tr>
     <td><a href="#contm_arccosh">arccosh</a></td>
     <td><a class="omsymbol" href="https://openmath.org/cd/transc1#arccosh">arccosh</a></td>
     <td><a class="intref" href="#contm_unary_elementary">unary-elementary</a></td>
-    <td></td>
-    <td></td>
-    <td></td>
     <td></td>
    </tr>
    <tr>
@@ -892,17 +724,11 @@
     <td><a class="omsymbol" href="https://openmath.org/cd/transc1#arctanh">arctanh</a></td>
     <td><a class="intref" href="#contm_unary_elementary">unary-elementary</a></td>
     <td></td>
-    <td></td>
-    <td></td>
-    <td></td>
    </tr>
    <tr>
     <td><a href="#contm_arcsech">arcsech</a></td>
     <td><a class="omsymbol" href="https://openmath.org/cd/transc1#arcsech">arcsech</a></td>
     <td><a class="intref" href="#contm_unary_elementary">unary-elementary</a></td>
-    <td></td>
-    <td></td>
-    <td></td>
     <td></td>
    </tr>
    <tr>
@@ -910,17 +736,11 @@
     <td><a class="omsymbol" href="https://openmath.org/cd/transc1#arccsch">arccsch</a></td>
     <td><a class="intref" href="#contm_unary_elementary">unary-elementary</a></td>
     <td></td>
-    <td></td>
-    <td></td>
-    <td></td>
    </tr>
    <tr>
     <td><a href="#contm_arccoth">arccoth</a></td>
     <td><a class="omsymbol" href="https://openmath.org/cd/transc1#arccoth">arccoth</a></td>
     <td><a class="intref" href="#contm_unary_elementary">unary-elementary</a></td>
-    <td></td>
-    <td></td>
-    <td></td>
     <td></td>
    </tr>
   </tbody>
@@ -930,17 +750,11 @@
     <td><a class="omsymbol" href="https://openmath.org/cd/veccalc1#divergence">divergence</a></td>
     <td><a class="intref" href="#contm_unary_veccalc">unary-veccalc</a></td>
     <td></td>
-    <td></td>
-    <td></td>
-    <td></td>
    </tr>
    <tr>
     <td><a href="#contm_grad">grad</a></td>
     <td><a class="omsymbol" href="https://openmath.org/cd/veccalc1#grad">grad</a></td>
     <td><a class="intref" href="#contm_unary_veccalc">unary-veccalc</a></td>
-    <td></td>
-    <td></td>
-    <td></td>
     <td></td>
    </tr>
    <tr>
@@ -948,17 +762,11 @@
     <td><a class="omsymbol" href="https://openmath.org/cd/veccalc1#curl">curl</a></td>
     <td><a class="intref" href="#contm_unary_veccalc">unary-veccalc</a></td>
     <td></td>
-    <td></td>
-    <td></td>
-    <td></td>
    </tr>
    <tr>
     <td><a href="#contm_laplacian">laplacian</a></td>
     <td><a class="omsymbol" href="https://openmath.org/cd/veccalc1#Laplacian">Laplacian</a></td>
     <td><a class="intref" href="#contm_unary_veccalc">unary-veccalc</a></td>
-    <td></td>
-    <td></td>
-    <td></td>
     <td></td>
    </tr>
   </tbody>
@@ -968,9 +776,6 @@
     <td><a class="omsymbol" href="https://openmath.org/cd/s_data1#moment">moment</a>,
     <a class="omsymbol" href="https://openmath.org/cd/s_dist1#moment">moment</a></td>
     <td><a class="intref" href="#contm_unary_functional">unary-functional</a></td>
-    <td></td>
-    <td></td>
-    <td></td>
     <td><code class="parsing_ref">degree</code>,
     <code class="parsing_ref">momentabout</code></td>
    </tr>
@@ -980,9 +785,6 @@
     <td><a href="#contm_log">log</a></td>
     <td><a class="omsymbol" href="https://openmath.org/cd/transc1#log">log</a></td>
     <td><a class="intref" href="#contm_unary_functional">unary-functional</a></td>
-    <td></td>
-    <td></td>
-    <td></td>
     <td><code class="parsing_ref">logbase</code></td>
    </tr>
   </tbody>
@@ -992,17 +794,11 @@
     <td><a class="omsymbol" href="https://openmath.org/cd/nums1#e">e</a></td>
     <td><a class="intref" href="#contm_constant_arith">constant-arith</a></td>
     <td></td>
-    <td></td>
-    <td></td>
-    <td></td>
    </tr>
    <tr>
     <td><a href="#contm_imaginaryi">imaginaryi</a></td>
     <td><a class="omsymbol" href="https://openmath.org/cd/nums1#i">i</a></td>
     <td><a class="intref" href="#contm_constant_arith">constant-arith</a></td>
-    <td></td>
-    <td></td>
-    <td></td>
     <td></td>
    </tr>
    <tr>
@@ -1010,17 +806,11 @@
     <td><a class="omsymbol" href="https://openmath.org/cd/nums1#NaN">NaN</a></td>
     <td><a class="intref" href="#contm_constant_arith">constant-arith</a></td>
     <td></td>
-    <td></td>
-    <td></td>
-    <td></td>
    </tr>
    <tr>
     <td><a href="#contm_true">true</a></td>
     <td><a class="omsymbol" href="https://openmath.org/cd/logic1#true">true</a></td>
     <td><a class="intref" href="#contm_constant_arith">constant-arith</a></td>
-    <td></td>
-    <td></td>
-    <td></td>
     <td></td>
    </tr>
    <tr>
@@ -1028,17 +818,11 @@
     <td><a class="omsymbol" href="https://openmath.org/cd/logic1#false">false</a></td>
     <td><a class="intref" href="#contm_constant_arith">constant-arith</a></td>
     <td></td>
-    <td></td>
-    <td></td>
-    <td></td>
    </tr>
    <tr>
     <td><a href="#contm_pi">pi</a></td>
     <td><a class="omsymbol" href="https://openmath.org/cd/nums1#pi">pi</a></td>
     <td><a class="intref" href="#contm_constant_arith">constant-arith</a></td>
-    <td></td>
-    <td></td>
-    <td></td>
     <td></td>
    </tr>
    <tr>
@@ -1046,17 +830,11 @@
     <td><a class="omsymbol" href="https://openmath.org/cd/nums1#gamma">gamma</a></td>
     <td><a class="intref" href="#contm_constant_arith">constant-arith</a></td>
     <td></td>
-    <td></td>
-    <td></td>
-    <td></td>
    </tr>
    <tr>
     <td><a href="#contm_infinity">infinity</a></td>
     <td><a class="omsymbol" href="https://openmath.org/cd/nums1#infinity">infinity</a></td>
     <td><a class="intref" href="#contm_constant_arith">constant-arith</a></td>
-    <td></td>
-    <td></td>
-    <td></td>
     <td></td>
    </tr>
   </tbody>
@@ -1066,17 +844,11 @@
     <td><a class="omsymbol" href="https://openmath.org/cd/setname1#Z">Z</a></td>
     <td><a class="intref" href="#contm_constant_set">constant-set</a></td>
     <td></td>
-    <td></td>
-    <td></td>
-    <td></td>
    </tr>
    <tr>
     <td><a href="#contm_reals">reals</a></td>
     <td><a class="omsymbol" href="https://openmath.org/cd/setname1#R">R</a></td>
     <td><a class="intref" href="#contm_constant_set">constant-set</a></td>
-    <td></td>
-    <td></td>
-    <td></td>
     <td></td>
    </tr>
    <tr>
@@ -1084,17 +856,11 @@
     <td><a class="omsymbol" href="https://openmath.org/cd/setname1#Q">Q</a></td>
     <td><a class="intref" href="#contm_constant_set">constant-set</a></td>
     <td></td>
-    <td></td>
-    <td></td>
-    <td></td>
    </tr>
    <tr>
     <td><a href="#contm_naturalnumbers">naturalnumbers</a></td>
     <td><a class="omsymbol" href="https://openmath.org/cd/setname1#N">N</a></td>
     <td><a class="intref" href="#contm_constant_set">constant-set</a></td>
-    <td></td>
-    <td></td>
-    <td></td>
     <td></td>
    </tr>
    <tr>
@@ -1102,17 +868,11 @@
     <td><a class="omsymbol" href="https://openmath.org/cd/setname1#C">C</a></td>
     <td><a class="intref" href="#contm_constant_set">constant-set</a></td>
     <td></td>
-    <td></td>
-    <td></td>
-    <td></td>
    </tr>
    <tr>
     <td><a href="#contm_primes">primes</a></td>
     <td><a class="omsymbol" href="https://openmath.org/cd/setname1#P">P</a></td>
     <td><a class="intref" href="#contm_constant_set">constant-set</a></td>
-    <td></td>
-    <td></td>
-    <td></td>
     <td></td>
    </tr>
    <tr>
@@ -1120,9 +880,6 @@
     <td><a class="omsymbol" href="https://openmath.org/cd/set1#emptyset">emptyset</a>,
     <a class="omsymbol" href="https://openmath.org/cd/multiset1#emptyset">emptyset</a></td>
     <td><a class="intref" href="#contm_constant_set">constant-set</a></td>
-    <td></td>
-    <td></td>
-    <td></td>
     <td></td>
    </tr>
   </tbody>
@@ -1132,9 +889,6 @@
     <td><a class="omsymbol" href="https://openmath.org/cd/quant1#forall">forall</a>,
     <a class="omsymbol" href="https://openmath.org/cd/logic1#implies">implies</a></td>
     <td><a class="intref" href="#contm_quantifier">quantifier</a></td>
-    <td></td>
-    <td></td>
-    <td></td>
     <td><code class="parsing_ref">BvarQ</code>,<code class="parsing_ref">DomainQ</code></td>
    </tr>
    <tr>
@@ -1142,9 +896,6 @@
     <td><a class="omsymbol" href="https://openmath.org/cd/quant1#exists">exists</a>,
     <a class="omsymbol" href="https://openmath.org/cd/logic1#and">and</a></td>
     <td><a class="intref" href="#contm_quantifier">quantifier</a></td>
-    <td></td>
-    <td></td>
-    <td></td>
     <td><code class="parsing_ref">BvarQ</code>,<code class="parsing_ref">DomainQ</code></td>
    </tr>
   </tbody>
@@ -1153,9 +904,6 @@
     <td><a href="#contm_lambda">lambda</a></td>
     <td><a class="omsymbol" href="https://openmath.org/cd/fns1#lambda">lambda</a></td>
     <td><a class="intref" href="#contm_lambda_container">lambda</a></td>
-    <td></td>
-    <td></td>
-    <td><code class="parsing_ref">ContExp</code></td>
     <td><code class="parsing_ref">BvarQ</code>,<code class="parsing_ref">DomainQ</code></td>
    </tr>
   </tbody>
@@ -1169,9 +917,6 @@
      <a class="omsymbol" href="https://openmath.org/cd/interval1#interval_oo">interval_oo</a>
     </td>
     <td><a class="intref" href="#contm_interval_sec">interval</a></td>
-    <td><code class="parsing_ref">closure</code>?</td>
-    <td><code class="attributevalue">open</code> | <code class="attributevalue">closed</code> | <code class="attributevalue">open-closed</code> | <code class="attributevalue">closed-open</code></td>
-    <td><code class="parsing_ref">ContExp</code>,<code class="parsing_ref">ContExp</code></td>
     <td></td>
    </tr>
   </tbody>
@@ -1181,9 +926,6 @@
     <td><a class="omsymbol" href="https://openmath.org/cd/calculus1#int">int</a> <a class="omsymbol" href="https://openmath.org/cd/calculus1#defint">defint</a></td>
     <td><a class="intref" href="#contm_int">int</a></td>
     <td></td>
-    <td></td>
-    <td></td>
-    <td></td>
    </tr>
   </tbody>
   <tbody id="cops_diff">
@@ -1191,9 +933,6 @@
     <td><a href="#contm_diff">diff</a></td>
     <td><a class="omsymbol" href="https://openmath.org/cd/calculus1#diff">diff</a></td>
     <td><a class="intref" href="#contm_diff">Differential-Operator</a></td>
-    <td></td>
-    <td></td>
-    <td></td>
     <td></td>
    </tr>
   </tbody>
@@ -1203,9 +942,6 @@
     <td><a class="omsymbol" href="https://openmath.org/cd/calculus1#partialdiff">partialdiff</a> <a class="omsymbol" href="https://openmath.org/cd/calculus1#partialdiffdegree">partialdiffdegree</a></td>
     <td><a class="intref" href="#contm_partialdiff">partialdiff</a></td>
     <td></td>
-    <td></td>
-    <td></td>
-    <td></td>
    </tr>
   </tbody>
   <tbody id="cops_sum">
@@ -1213,9 +949,6 @@
     <td><a href="#contm_sum">sum</a></td>
     <td><a class="omsymbol" href="https://openmath.org/cd/arith1#sum">sum</a></td>
     <td><a class="intref" href="#contm_sum">sum</a></td>
-    <td></td>
-    <td></td>
-    <td></td>
     <td><code class="parsing_ref">BvarQ</code>,<code class="parsing_ref">DomainQ</code></td>
    </tr>
   </tbody>
@@ -1224,9 +957,6 @@
     <td><a href="#contm_product">product</a></td>
     <td><a class="omsymbol" href="https://openmath.org/cd/arith1#product">product</a></td>
     <td><a class="intref" href="#contm_product">product</a></td>
-    <td></td>
-    <td></td>
-    <td></td>
     <td><code class="parsing_ref">BvarQ</code>,<code class="parsing_ref">DomainQ</code></td>
    </tr>
   </tbody>
@@ -1241,9 +971,6 @@
      <a class="omsymbol" href="https://openmath.org/cd/limit1#null">null</a>
     </td>
     <td><a class="intref" href="#contm_limit">limit</a></td>
-    <td></td>
-    <td></td>
-    <td></td>
     <td>
      <code class="parsing_ref">lowlimit</code>,
      <code class="parsing_ref">condition</code>
@@ -1251,14 +978,10 @@
    </tr>
   </tbody>
   <tbody id="cops_piecewise">
-    <tr>
+   <tr>
     <td><a href="#contm_piecewise">piecewise</a></td>
     <td><a class="omsymbol" href="https://openmath.org/cd/piece1#piecewise">piecewise</a></td>
     <td><a class="intref" href="#contm_container_constructor">Constructor</a></td>
-    <td></td>
-    <td></td>
-    <td><code class="parsing_ref">piece</code>*,
-    <code class="parsing_ref">otherwise</code>?</td>
     <td></td>
    </tr>
    <tr>
@@ -1266,17 +989,11 @@
     <td><a class="omsymbol" href="https://openmath.org/cd/piece1#piece">piece</a></td>
     <td><a class="intref" href="#contm_container_constructor">Constructor</a></td>
     <td></td>
-    <td></td>
-    <td><code class="parsing_ref">ContExp</code>,<code class="parsing_ref">ContExp</code></td>
-    <td></td>
    </tr>
    <tr>
     <td><a href="#contm_piecewise">otherwise</a></td>
     <td><a class="omsymbol" href="https://openmath.org/cd/piece1#otherwise">otherwise</a></td>
     <td><a class="intref" href="#contm_container_constructor">Constructor</a></td>
-    <td></td>
-    <td></td>
-    <td><code class="parsing_ref">ContExp</code></td>
     <td></td>
    </tr>
   </tbody>
@@ -1285,21 +1002,16 @@
     <td><a href="#contm_set">set</a></td>
     <td><a class="omsymbol" href="https://openmath.org/cd/set1#set">set</a>, <a class="omsymbol" href="https://openmath.org/cd/multiset1#multiset">multiset</a></td>
     <td><a class="intref" href="#contm_nary_construct_set">nary-setlist-constructor</a></td>
-    <td><code class="parsing_ref">type</code>?</td>
-    <td><code class="attributevalue">set</code> | <code class="attributevalue">multiset</code> | text </td>
-    <td><code class="parsing_ref">ContExp</code>*</td>
     <td><code class="parsing_ref">BvarQ</code>,<code class="parsing_ref">DomainQ</code></td>
    </tr>
    <tr>
     <td><a href="#contm_list">list</a></td>
     <td><a class="omsymbol" href="https://openmath.org/cd/interval1#interval_cc">interval_cc</a>, <a class="omsymbol" href="https://openmath.org/cd/list1#list">list</a></td>
     <td><a class="intref" href="#contm_nary_construct_set">nary-setlist-constructor</a></td>
-    <td><code class="parsing_ref">order</code></td>
-    <td><code class="attributevalue">numeric</code> | <code class="attributevalue">lexicographic</code></td>
-    <td><code class="parsing_ref">ContExp</code>*</td>
     <td><code class="parsing_ref">BvarQ</code>,<code class="parsing_ref">DomainQ</code></td>
    </tr>
   </tbody>
  </table>
+ </section>
 
 </section>


### PR DESCRIPTION
I've created separate operator element tables in the appendix to list the content models for container elements, and to list the attributes of content operators.

I've also reviewed and updated the text in section 4.3.1 Container Markup, and made sure the attribute values are described in the element-specific sections of 4.3.

Closes #318