### PR TITLE
use exising number definiton from chapter2

### DIFF
--- a/src/fundamentals.html
+++ b/src/fundamentals.html
@@ -189,7 +189,7 @@
       </tr>
 
       <tr>
-       <td id="type_number"><em>number</em></td>
+       <td id="type_number"><dfn><em>number</em></dfn></td>
        <td>
         an optional prefix of "-" (U+002D), followed by an <a href="#type_unsigned-number">unsigned number</a>,
        representing a terminating decimal number (a type of rational number)</td>

--- a/src/mixing.html
+++ b/src/mixing.html
@@ -108,12 +108,11 @@ the user and agent.</p>
 <pre class="def bnf">
 intent   := number | NCName | argref | function
 function := (NCName | argref) '(' intent [ ',' intent ]* ')'
-number   := '-'? digit+ ('.' digit+)? 
 argref   := '$' NCName
 </pre>
 
 <p>Here <a href="https://www.w3.org/TR/REC-xml-names/#NT-NCName"><code>NCName</code></a>
-is as defined in  in [[xml-names]], and <code>digit</code> is a character in the range 0–9.</p>
+is as defined in  in [[xml-names]], and  [=number=] is as defined in [[[#syntax-notation-used-in-the-mathml-specification]]].</p>
   </section>
 
 


### PR DESCRIPTION
This removes the ad-hoc definition of `number` from the intent grammar and instead references the existing definition in chapter 2

https://w3c.github.io/mathml/#syntax-notation-used-in-the-mathml-specification

That definition is based on unsigned-number and defers to CSS for the fine print.


This also addresss issue #376


![image](https://user-images.githubusercontent.com/1268738/171207960-f84b3418-5da6-47d4-bd0a-ed87c608858e.png)


