### PR TITLE
use respec dfn links

### DIFF
--- a/src/fundamentals.html
+++ b/src/fundamentals.html
@@ -189,19 +189,19 @@
       </tr>
 
       <tr>
-       <td id="type_number"><em>number</em></td>
+       <td id="type_number"><dfn><em>number</em></dfn></td>
        <td>
         an optional prefix of "-" (U+002D), followed by an <a href="#type_unsigned-number">unsigned number</a>,
        representing a terminating decimal number (a type of rational number)</td>
       </tr>
 
       <tr>
-       <td id="type_character"><em>character</em></td>
+       <td id="type_character"><dfn><em>character</em></dfn></td>
        <td>a single non-whitespace character</td>
       </tr>
 
       <tr>
-       <td id="type_string"><em>string</em></td>
+       <td id="type_string"><dfn><em>string</em></dfn></td>
        <td>an arbitrary, nonempty and finite, string of <em>character</em>s</td>
       </tr>
 
@@ -216,24 +216,24 @@
       </tr>
 
       <tr>
-       <td id="type_color"><em>color</em></td>
+       <td id="type_color"><dfn><em>color</em></dfn></td>
        <td>a color, using the syntax specified by [[CSS-Color-3]]</td>
       </tr>
 
       <tr>
-       <td id="type_id"><em>id</em></td>
+       <td id="type_id"><dfn><em>id</em></dfn></td>
        <td>an identifier, unique within the document;
        must satisfy the NAME syntax of the XML recommendation [[XML]]</td>
       </tr>
 
       <tr>
-       <td id="type_idref"><em>idref</em></td>
+       <td id="type_idref"><dfn><em>idref</em></dfn></td>
        <td>an identifier referring to another element within the document;
        must satisfy the NAME syntax of the XML recommendation [[XML]]</td>
       </tr>
 
       <tr>
-       <td id="type_uri"><em>URI</em></td>
+       <td id="type_uri"><dfn><em>URI</em></dfn></td>
        <td>a Uniform Resource Identifier [[RFC3986]]. Note that the attribute value
        is typed in the schema as anyURI which allows any sequence of XML characters.
        Systems needing to use this string as a URI must encode the bytes of the UTF-8 encoding
@@ -540,7 +540,7 @@
 
      <tr>
       <td rowspan="2" class="attname">id</td>
-      <td><a class="intref" href="#type_id"><em>id</em></a></td>
+      <td><em>[^id^]</em></td>
       <td><em>none</em></td>
       <td><a class="coreyes" href="https://w3c.github.io/mathml-core/spec.html#dfn-id"></a></td>
      </tr>
@@ -555,7 +555,7 @@
 
      <tr>
       <td rowspan="2" class="attname">xref</td>
-      <td><a class="intref" href="#type_idref"><em>idref</em></a></td>
+      <td><em>[^idref^]</em></td>
       <td><em>none</em></td>
       <td><span class="coreno"></span></td>
      </tr>
@@ -569,7 +569,7 @@
 
      <tr>
       <td rowspan="2" class="attname">class</td>
-      <td><a class="intref" href="#type_string"><em>string</em></a></td>
+      <td><em>[^string^]</em></td>
       <td><em>none</em></td>
       <td><a class="coreyes" href="https://w3c.github.io/mathml-core/spec.html#dfn-class"></a></td>
      </tr>
@@ -584,7 +584,7 @@
 
      <tr>
       <td rowspan="2" class="attname">style</td>
-      <td><a class="intref" href="#type_string"><em>string</em></a></td>
+      <td><em>[^string^]</em></td>
       <td><em>none</em></td>
       <td><a class="coreyes" href="https://w3c.github.io/mathml-core/spec.html#dfn-style"></a></td>
      </tr>
@@ -648,7 +648,7 @@
 
      <tr>
       <td rowspan="2" class="attname">other</td>
-      <td><a class="intref" href="#type_string"><em>string</em></a></td>
+      <td><em>[^string^]</em></td>
       <td><em>none</em></td>
       <td><span class="coreno"></span></td>
      </tr>
@@ -919,7 +919,7 @@
 
      <tr>
       <td rowspan="2" class="attname">alttext</td>
-      <td><a class="intref" href="#type_string"><em>string</em></a></td>
+      <td><em>[^string^]</em></td>
       <td><em>none</em></td>
       <td><span class="coreno"></span></td>
      </tr>

--- a/src/mixing.html
+++ b/src/mixing.html
@@ -675,7 +675,7 @@ topics.</p>
 
       <tr>
        <td rowspan="2" class="attname">encoding</td>
-       <td><a class="intref" href="#type_string"><em>string</em></a></td>
+       <td><em>[^string^]</em></td>
        <td><em>none</em></td>
       </tr>
 
@@ -685,7 +685,7 @@ topics.</p>
 
       <tr>
        <td rowspan="2" class="attname">cd</td>
-       <td><a class="intref" href="#type_string"><em>string</em></a></td>
+       <td><em>[^string^]</em></td>
        <td>mathmlkeys</td>
       </tr>
 
@@ -695,7 +695,7 @@ topics.</p>
 
       <tr>
        <td rowspan="2" class="attname">name</td>
-       <td><a class="intref" href="#type_string"><em>string</em></a></td>
+       <td><em>[^string^]</em></td>
        <td>alternate-representation</td>
       </tr>
 
@@ -791,7 +791,7 @@ topics.</p>
 
       <tr>
        <td rowspan="2" class="attname">encoding</td>
-       <td><a class="intref" href="#type_string"><em>string</em></a></td>
+       <td><em>[^string^]</em></td>
        <td><em>none</em></td>
       </tr>
 
@@ -801,7 +801,7 @@ topics.</p>
 
       <tr>
        <td rowspan="2" class="attname">cd</td>
-       <td><a class="intref" href="#type_string"><em>string</em></a></td>
+       <td><em>[^string^]</em></td>
        <td>mathmlkeys</td>
       </tr>
 
@@ -811,7 +811,7 @@ topics.</p>
 
       <tr>
        <td rowspan="2" class="attname">name</td>
-       <td><a class="intref" href="#type_string"><em>string</em></a></td>
+       <td><em>[^string^]</em></td>
        <td>alternate-representation</td>
       </tr>
 

--- a/src/operator-dict.html
+++ b/src/operator-dict.html
@@ -46,7 +46,7 @@
 
   <p>The values for <code class="attribute">lspace</code> and <code
   class="attribute">rspace</code> given here range from 0 to 7
-  denoting multiples of 1/18&#x2009;em matching the values used for <a href="#type_namedspace">named space</a>.</p>
+  denoting multiples of 1/18&#x2009;em matching the values used for [^namedspace^].</p>
 
   <p>
    For the invisible operators whose content is <code class="entity">InvisibleTimes</code> or <code class="entity">ApplyFunction</code>,

--- a/src/presentation-markup.html
+++ b/src/presentation-markup.html
@@ -1092,7 +1092,7 @@
  
      <tr>
       <td rowspan="2" class="attname">mathcolor</td>
-      <td><a class="intref" href="#type_color"><em>color</em></a></td>
+      <td><em>[^color^]</a></td>
       <td><em>inherited</em></td>
       <td><a class="coreyes" href="https://w3c.github.io/mathml-core/spec.html#mathmltree.p4"></a></td>
      </tr>
@@ -1108,7 +1108,7 @@
  
      <tr>
       <td rowspan="2" class="attname">mathbackground</td>
-      <td><a class="intref" href="#type_color"><em>color</em></a> | "transparent"</td>
+      <td><em>[^color^]</em> | "transparent"</td>
       <td>transparent</td>
       <td><a class="coreyes" href="https://w3c.github.io/mathml-core/spec.html#dfn-mathbackground"></a></td>
      </tr>
@@ -1267,7 +1267,7 @@
  
        <tr>
         <td rowspan="2" class="attname">src</td>
-        <td><a class="intref" href="#type_uri"><em>URI</em></a></td>
+        <td><em>[^URI^]</em></a></td>
         <td><em>required</em></td>
         <td><span class="coreno"></span></td>
        </tr>
@@ -1327,7 +1327,7 @@
  
        <tr>
         <td rowspan="2" class="attname">alt</td>
-        <td><a class="intref" href="#type_string"><em>string</em></a></td>
+        <td><em>[^string^]</em></td>
         <td><em>required</em></td>
         <td><span class="coreno"></span></td>
        </tr>
@@ -2275,7 +2275,7 @@
  
        <tr>
         <td rowspan="2" class="attname">linebreakmultchar</td>
-        <td><a class="intref" href="#type_string"><em>string</em></a></td>
+        <td><em>[^string^]</em></td>
         <td><em>inherited</em> (&amp;InvisibleTimes;) </td>
         <td><span class="coreno"></span></td>
        </tr>
@@ -2375,14 +2375,14 @@
  
        <tr>
         <td rowspan="2" class="attname">indenttarget</td>
-        <td><a class="intref" href="#type_idref"><em>idref</em></a></td>
+        <td><em>[^idref^]</em></a></td>
         <td><em> inherited (none)</em></td>
         <td><span class="coreno"></span></td>
        </tr>
  
        <tr>
         <td colspan="3" class="attdesc">
-   Specifies the <a class="intref" href="#type_id">id</a> of another element
+   Specifies the [^id^] of another element
    whose horizontal position determines the position of indented lines
    when <code class="attribute">indentalign</code>=<code class="attributevalue">id</code>.
    Note that the identified element may be outside of the current
@@ -2505,7 +2505,7 @@
        <tr>
         <td> id           </td>
         <td> Align the left side of the next line to the left side of the element
-        referenced by the <a class="intref" href="#type_idref"><em>idref</em></a>
+        referenced by the <em>[^idref^]</a>
         (given by <code class="attribute">indenttarget</code>);
         if no such element exists, use <code class="attributevalue">auto</code> as the <code class="attribute">indentalign</code> value</td>
        </tr>
@@ -3585,7 +3585,7 @@
  
   <tr>
  <td rowspan="2" class="attname">lquote</td>
- <td><a class="intref" href="#type_string"><em>string</em></a></td>
+ <td><em>[^string^]</em></td>
  <td><code class="entity">quot</code></td>
  <td><span class="coreno"></span></td>
  </tr>
@@ -3599,7 +3599,7 @@
  
  <tr>
  <td rowspan="2" class="attname">rquote</td>
- <td><a class="intref" href="#type_string"><em>string</em></a></td>
+ <td><em>[^string^]</em></td>
  <td><code class="entity">quot</code></td>
  <td><span class="coreno"></span></td>
  </tr>
@@ -4326,7 +4326,7 @@
  
  <tr>
  <td rowspan="2" class="attname">scriptsizemultiplier</td>
- <td><a class="intref" href="#type_number"><em>number</em></a></td>
+ <td><em>[^number^]</em></a></td>
  <td>0.71</td>
  <td><span class="coreno"></span></td>
  </tr>
@@ -4370,7 +4370,7 @@
  
  <tr>
  <td rowspan="2" class="attname">decimalpoint</td>
- <td><a class="intref" href="#type_character"><em>character</em></a></td>
+ <td><a class="intref" href="#type_character"><em>[^character^]</em></a></td>
  <td>.</td>
  <td><span class="coreno"></span></td>
  </tr>
@@ -5190,7 +5190,7 @@
  
      <tr>
       <td rowspan="2" class="attname">open</td>
-      <td><a class="intref" href="#type_string"><em>string</em></a></td>
+      <td><em>[^string^]</em></td>
       <td>(</td>
       <td><span class="coreno"></span></td>
      </tr>
@@ -5205,7 +5205,7 @@
  
      <tr>
       <td rowspan="2" class="attname">close</td>
-      <td><a class="intref" href="#type_string"><em>string</em></a></td>
+      <td><em>[^string^]</em></td>
       <td>)</td>
       <td><span class="coreno"></span></td>
      </tr>
@@ -5220,7 +5220,7 @@
  
      <tr>
       <td rowspan="2" class="attname">separators</td>
-      <td><a class="intref" href="#type_string"><em>string</em></a></td>
+      <td><em>[^string^]</em></td>
       <td>,</td>
       <td><span class="coreno"></span></td>
      </tr>
@@ -8888,7 +8888,7 @@
  
  <tr>
  <td rowspan="2" class="attname">scriptsizemultiplier</td>
- <td> <a class="intref" href="#type_number"><em>number</em></a></td>
+ <td><em><em>[^number^]</em></td>
  <td><em>inherited (0.6)</em></td>
  <td><span class="coreno"></span></td>
  </tr>
@@ -9630,7 +9630,7 @@
  
    <tr>
     <td rowspan="2" class="attname">actiontype</td>
-    <td><a class="intref" href="#type_string"><em>string</em></a></td>
+    <td><em>[^string^]</em></td>
     <td><em>required</em></td>
     <td><span class="coreno"></span></td>
    </tr>


### PR DESCRIPTION
As discussed  in #376 and  #377 this uses `<dfn>` for all defined terms in 

https://w3c.github.io/mathml/#syntax-notation-used-in-the-mathml-specification

and uses respec `[^term^]` markup for all references to those terms.

The current main branch is inconsistent between this markup and older direct HTML links.

The effect is that all defined terms in the first column are bold and clicking on them provides a pop-up that lists where they are used.

No textual changes are made in this PR, Just internal markup changes.

