### PR TITLE
elem math changes -- moved the images into "mml4p" tags, but as comments

### DIFF
--- a/src/presentation-markup.html
+++ b/src/presentation-markup.html
@@ -8385,11 +8385,11 @@
       &lt;msline/&gt;
     &lt;/mstack&gt;
  </pre>
- <!-- <blockquote>
-  <img src="image/em-plus.png" alt="\begin{array}{r}   424 \\   +33 \\   \hline \end{array}"/>
-  </blockquote> -->
  </div>
- 
+ <blockquote>
+  <img src="image/em-plus.png" alt="\begin{array}{r}   424 \\   +33 \\   \hline \end{array}"/>
+ </blockquote>
+
  <p> Many more examples are given in <a href="#presm_elemmath_examples"></a>.</p>
  
  <section>
@@ -9119,11 +9119,11 @@
       &lt;msline/&gt;
     &lt;/mstack&gt;
  </pre>
- <!-- <blockquote>
-  <img src="image/em-plus-shift.png" alt="\begin{array}{@{}r@{}}    424 \\   +\phantom0 33 \\   \hline \end{array}"/>
-  </blockquote> -->
  </div>
- 
+ <blockquote>
+  <img src="image/em-plus-shift.png" alt="\begin{array}{@{}r@{}}    424 \\   +\phantom0 33 \\   \hline \end{array}"/>
+  </blockquote>
+
  <p>The next example illustrates how to put an operator on the right. Placing the
  operator on the right is standard in the Netherlands and some other countries.
  Notice that although there are a total of four columns in the example,
@@ -9139,10 +9139,10 @@
       &lt;mn&gt;579&lt;/mn&gt;
     &lt;/mstack&gt;
  </pre>
- <!-- <blockquote>
-  <img src="image/em-plus-right.png" alt="\begin{array}{l}   123 \\   456+ \\   \hline   579 \end{array}"/>
-  </blockquote> -->
  </div>
+ <blockquote>
+  <img src="image/em-plus-right.png" alt="\begin{array}{l}   123 \\   456+ \\   \hline   579 \end{array}"/>
+  </blockquote>
  
  <p>The following two examples illustrate the use of <code class="element">mscarries</code>,
  <code class="element">mscarry</code> and using <code class="element">none</code> to fill in a column.
@@ -9160,11 +9160,11 @@
       &lt;mn&gt;1,171&lt;/mn&gt;
     &lt;/mstack&gt;
  </pre>
- <!-- <blockquote>
-  <img src="image/em-sub-borrow-above.png" alt=""/>
- </blockquote> -->
 </div>
- 
+ <blockquote>
+  <img src="image/em-sub-borrow-above.png" alt=""/>
+ </blockquote>
+
  <div class="example mathml mml4p">
   <pre>
     &lt;mstack&gt;
@@ -9180,10 +9180,10 @@
       &lt;mn&gt;1,171&lt;/mn&gt;
     &lt;/mstack&gt;
  </pre>
- <!-- <blockquote>
-  <img src="image/em-sub-borrow-aboveleft.png" alt=""/>
- </blockquote> -->
 </div>
+<blockquote>
+  <img src="image/em-sub-borrow-aboveleft.png" alt=""/>
+ </blockquote>
  <p>The MathML for the second example uses <code class="element">mscarry</code> because a crossout should only happen on a single column:</p>
  
 
@@ -9207,11 +9207,11 @@
       &lt;mn&gt;45&lt;/mn&gt;
     &lt;/mstack&gt;
  </pre>
- <!-- <blockquote>
-  <img src="image/em-sub-borrow-swedish.png" alt="\begin{array}{r} \underbar{\scriptsize 10}\!\\ 5\llap{$/$}2\\ {}-{}7\\ \hline 45 \end{array}"/>
- </blockquote> -->
   </div>
- 
+  <blockquote>
+    <img src="image/em-sub-borrow-swedish.png" alt="\begin{array}{r} \underbar{\scriptsize 10}\!\\ 5\llap{$/$}2\\ {}-{}7\\ \hline 45 \end{array}"/>
+   </blockquote>
+   
  </section>
  
  <section class="fold">
@@ -9242,10 +9242,10 @@
       &lt;msline/&gt;
     &lt;/mstack&gt;
  </pre>
- <!-- <blockquote>
-  <img src="image/em-mult-simple.png" alt=""/>
-  </blockquote> -->
 </div>
+<blockquote>
+  <img src="image/em-mult-simple.png" alt=""/>
+  </blockquote>
  
  <p>The following is a more complicated example of multiplication that has multiple rows of carries. It also (somewhat
  artificially) includes commas (",") as digit separators. The encoding includes
@@ -9281,11 +9281,11 @@
       &lt;mn&gt;5,332,114&lt;/mn&gt;
     &lt;/mstack&gt;
  </pre>
-  <!-- <blockquote>
-   <img src="image/em-mult-carries.png" alt="\begin{array}{r}  {}_1 {\hspace{0.05em}}_1\phantom{0} \\  {}_1 {\hspace{0.05em}}_1\phantom{0} \\   1,234 \\   \times 4,321 \\   \hline  {}_1 \phantom{,} {\hspace{0.05em \,}}_1 {\hspace{0.05em}}_1  {\hspace{0.05em}}_1 \phantom{,} {\hspace{0.05em \,}}_1 \phantom{00} \\   1,234 \\   24,68\phantom{0} \\   370,2\phantom{00} \\   4,936\phantom{,000} \\   \hline   5,332,114 \end{array}"/>
-  </blockquote> -->
 </div>
- 
+<blockquote>
+  <img src="image/em-mult-carries.png" alt="\begin{array}{r}  {}_1 {\hspace{0.05em}}_1\phantom{0} \\  {}_1 {\hspace{0.05em}}_1\phantom{0} \\   1,234 \\   \times 4,321 \\   \hline  {}_1 \phantom{,} {\hspace{0.05em \,}}_1 {\hspace{0.05em}}_1  {\hspace{0.05em}}_1 \phantom{,} {\hspace{0.05em \,}}_1 \phantom{00} \\   1,234 \\   24,68\phantom{0} \\   370,2\phantom{00} \\   4,936\phantom{,000} \\   \hline   5,332,114 \end{array}"/>
+ </blockquote>
+
  </section>
  
  <section class="fold">
@@ -9443,11 +9443,11 @@
       &lt;/msgroup&gt;
     &lt;/mlongdiv&gt;
  </pre>
-  <!-- <blockquote>
-   <img src="image/em-longdiv-us.png" alt=""/>
-  </blockquote> -->
  </div>
- 
+ <blockquote>
+  <img src="image/em-longdiv-us.png" alt=""/>
+ </blockquote>
+
  <p>
   With the exception of the last example,
   the encodings for the other examples are the same except that the values for
@@ -9490,10 +9490,10 @@
       &lt;/mlongdiv&gt;
     &lt;/mstyle&gt;
  </pre>
-  <!-- <blockquote>
-   <img src="image/em-longdiv-arabic-lefttop.png" alt=""/>
-  </blockquote> -->
- </div>
+  </div>
+  <blockquote>
+  <img src="image/em-longdiv-arabic-lefttop.png" alt=""/>
+  </blockquote>
  
  </section>
  
@@ -9517,11 +9517,11 @@
       &lt;msline length="1"/&gt;
       &lt;mn&gt; 0.3333 &lt;/mn&gt;
     &lt;/mstack&gt;
- </pre>
-  <!-- <blockquote>
-   <img src="image/repeat1.png" alt="0.33333 \overline{3}"/>
-  </blockquote> -->
- </div>
+  </pre>
+  </div>
+  <blockquote>
+  <img src="image/repeat1.png" alt="0.33333 \overline{3}"/>
+  </blockquote>
  
  <div class="example mathml mml4p">
   <pre>
@@ -9530,10 +9530,10 @@
       &lt;mn&gt; 0.142857 &lt;/mn&gt;
     &lt;/mstack&gt;
  </pre>
- <!-- <blockquote>
-  <img src="image/repeat2.png" alt="0.\overline{142857}"/>
- </blockquote> -->
  </div>
+ <blockquote>
+  <img src="image/repeat2.png" alt="0.\overline{142857}"/>
+ </blockquote>
 
  <div class="example mathml mml4p">
   <pre>
@@ -9542,10 +9542,10 @@
       &lt;msline length="6"/&gt;
     &lt;/mstack&gt;
  </pre>
- <!-- <blockquote>
-  <img src="image/repeat3.png" alt="0.\underline{142857}"/>
- </blockquote> -->
  </div>
+ <blockquote>
+  <img src="image/repeat3.png" alt="0.\underline{142857}"/>
+ </blockquote>
  
  <div class="example mathml mml4p">
   <pre>
@@ -9554,11 +9554,11 @@
       &lt;mn&gt; 0.142857 &lt;/mn&gt;
     &lt;/mstack&gt;
   </pre>
-  <!-- <blockquote>
-    <img src="image/repeat4.png" alt="0.\dot{1}4285\dot{7}"/>
-  </blockquote> -->
-   </div> 
- 
+  </div> 
+  <blockquote>
+   <img src="image/repeat4.png" alt="0.\dot{1}4285\dot{7}"/>
+  </blockquote>
+  
  </section>
  </section>
  </section>

--- a/src/presentation-markup.html
+++ b/src/presentation-markup.html
@@ -8376,14 +8376,7 @@
   In addition to two-dimensional addition, subtraction, multiplication, and long division,
  these elements can be used to represent several notations used for repeating decimals.</p>
  
- <p>A very simple example of two-dimensional addition is shown below:</p>
- 
- <blockquote>
- <img src="image/em-plus.png" alt="\begin{array}{r}   424 \\   +33 \\   \hline \end{array}"/>
- </blockquote>
- 
- <p>The MathML for this is:</p>
- 
+ <p>A very simple example of two-dimensional addition is shown below:</p> 
  <div class="example mathml mml4p">
   <pre>
     &lt;mstack&gt;
@@ -8392,6 +8385,9 @@
       &lt;msline/&gt;
     &lt;/mstack&gt;
  </pre>
+ <!-- <blockquote>
+  <img src="image/em-plus.png" alt="\begin{array}{r}   424 \\   +33 \\   \hline \end{array}"/>
+  </blockquote> -->
  </div>
  
  <p> Many more examples are given in <a href="#presm_elemmath_examples"></a>.</p>
@@ -9110,13 +9106,10 @@
  involve numbers, carries/borrows, lines, and the sign of the
  operation.</p>
  
- <p>Notice that the <code class="element">msline</code> spans all of the columns and that <code class="element">none</code> is used to make the "+" appear to the left of all of the operands.</p>
- 
- <blockquote>
- <img src="image/em-plus-shift.png" alt="\begin{array}{@{}r@{}}    424 \\   +\phantom0 33 \\   \hline \end{array}"/>
- </blockquote>
- 
- <p>The MathML for this is:</p>
+ <p> Below is the example shown at the start of the section:
+   the digits inside the <code class="element">mn</code> elements each occupy a column as does the "+".
+   <code class="element">none</code> is used to fill in the column under the "4" and make the "+" appear to the left of all of the operands.
+   Notice that no attributes are given on <code class="element">msline</code> causing it to span all of the columns. </p>
  
  <div class="example mathml mml4p">
   <pre>
@@ -9126,17 +9119,16 @@
       &lt;msline/&gt;
     &lt;/mstack&gt;
  </pre>
+ <!-- <blockquote>
+  <img src="image/em-plus-shift.png" alt="\begin{array}{@{}r@{}}    424 \\   +\phantom0 33 \\   \hline \end{array}"/>
+  </blockquote> -->
  </div>
  
- <p>Here is an example with the operator on the right. Placing the
+ <p>The next example illustrates how to put an operator on the right. Placing the
  operator on the right is standard in the Netherlands and some other countries.
  Notice that although there are a total of four columns in the example,
  because the default alignment <span>is</span> on the implied decimal point to the right of the numbers,
- it is not necessary to pad any row.</p>
- 
- <blockquote>
- <img src="image/em-plus-right.png" alt="\begin{array}{l}   123 \\   456+ \\   \hline   579 \end{array}"/>
- </blockquote>
+ it is not necessary to pad or shift any row.</p>
  
  <div class="example mathml mml4p">
   <pre>
@@ -9147,35 +9139,14 @@
       &lt;mn&gt;579&lt;/mn&gt;
     &lt;/mstack&gt;
  </pre>
+ <!-- <blockquote>
+  <img src="image/em-plus-right.png" alt="\begin{array}{l}   123 \\   456+ \\   \hline   579 \end{array}"/>
+  </blockquote> -->
  </div>
- 
- <p>Because the default alignment is placed to the right of number, the
- numbers align properly and none of the rows need to be shifted.</p>
  
  <p>The following two examples illustrate the use of <code class="element">mscarries</code>,
  <code class="element">mscarry</code> and using <code class="element">none</code> to fill in a column.
- The examples illustrate two different ways of displaying a borrow.</p>
- 
- <table>
- 
-  <tbody>
- 
-   <tr>
-    <td>
-     <blockquote>
- <img src="image/em-sub-borrow-above.png" alt=""/>
- </blockquote>
- </td>
- <td>
-  <blockquote>
-   <img src="image/em-sub-borrow-aboveleft.png" alt=""/>
-  </blockquote>
- </td>
- </tr>
- </tbody>
- </table>
- 
- <p>The MathML for the first example is:</p>
+ The examples also illustrate two different ways of displaying a borrow.</p>
  
  <div class="example mathml mml4p">
   <pre>
@@ -9189,9 +9160,10 @@
       &lt;mn&gt;1,171&lt;/mn&gt;
     &lt;/mstack&gt;
  </pre>
- </div>
- 
- <p>The MathML for the second example uses <code class="element">mscarry</code> because a crossout should only happen on a single column:</p>
+ <!-- <blockquote>
+  <img src="image/em-sub-borrow-above.png" alt=""/>
+ </blockquote> -->
+</div>
  
  <div class="example mathml mml4p">
   <pre>
@@ -9208,19 +9180,18 @@
       &lt;mn&gt;1,171&lt;/mn&gt;
     &lt;/mstack&gt;
  </pre>
- </div>
+ <!-- <blockquote>
+  <img src="image/em-sub-borrow-aboveleft.png" alt=""/>
+ </blockquote> -->
+</div>
+ <p>The MathML for the second example uses <code class="element">mscarry</code> because a crossout should only happen on a single column:</p>
  
- <p>Here is an example of subtraction where there is a borrow with
- multiple digits in a single column and a cross out. The borrowed
- amount is underlined (the example is from a <a href="http://www.fritext.se/matte/grunder/posi2.html">Swedish
- source</a>):</p>
- 
- <blockquote>
- <img src="image/em-sub-borrow-swedish.png" alt="\begin{array}{r} \underbar{\scriptsize 10}\!\\ 5\llap{$/$}2\\ {}-{}7\\ \hline 45 \end{array}"/>
- </blockquote>
- 
- <p>There are two things to notice.
- The first is that <code class="element">menclose</code> is used in the carry and that <code class="element">none</code> is used for
+
+ <p>The next example of subtraction shows a borrowed
+ amount that is underlined (the example is from a <a href="http://www.fritext.se/matte/grunder/posi2.html">Swedish
+ source</a>).
+ There are two things to notice:
+ an <code class="element">menclose</code> is used in the carry, and <code class="element">none</code> is used for
  the empty element so that <code class="element">mscarry</code> can be used to create a crossout.</p>
  
  <div class="example mathml mml4p">
@@ -9236,7 +9207,10 @@
       &lt;mn&gt;45&lt;/mn&gt;
     &lt;/mstack&gt;
  </pre>
- </div>
+ <!-- <blockquote>
+  <img src="image/em-sub-borrow-swedish.png" alt="\begin{array}{r} \underbar{\scriptsize 10}\!\\ 5\llap{$/$}2\\ {}-{}7\\ \hline 45 \end{array}"/>
+ </blockquote> -->
+  </div>
  
  </section>
  
@@ -9244,14 +9218,13 @@
  <h5 id="presm_mult">Multiplication</h5>
  
  <p>Below is a simple multiplication example that illustrates the use of <code class="element">msgroup</code> and
- the <code class="attribute">shift</code> attribute. The first <code class="element">msgroup</code> does nothing.
- The second <code class="element">msgroup</code> could also be removed, but <code class="element">msrow</code> would be needed for its second and third children.
- They would set the <code class="attribute">position</code> or <code class="attribute">shift</code> attributes, or would add <code class="element">none</code> elements.
+ the <code class="attribute">shift</code> attribute. The first <code class="element">msgroup</code> is implied and doesn't
+ change the layout.
+ The second <code class="element">msgroup</code> could also be removed, but <code class="element">msrow</code> would be needed for last two children.
+ They <code class="element">msrow</code> would need to set the
+ <code class="attribute">position</code> or <code class="attribute">shift</code> attributes,
+ or would add <code class="element">none</code> elements to pad the digits on the right.
  </p>
- 
- <blockquote>
- <img src="image/em-mult-simple.png" alt=""/>
- </blockquote>
  
  <div class="example mathml mml4p">
   <pre>
@@ -9269,16 +9242,15 @@
       &lt;msline/&gt;
     &lt;/mstack&gt;
  </pre>
- </div>
+ <!-- <blockquote>
+  <img src="image/em-mult-simple.png" alt=""/>
+  </blockquote> -->
+</div>
  
- <p>This example has multiple rows of carries. It also (somewhat
+ <p>The following is a more complicated example of multiplication that has multiple rows of carries. It also (somewhat
  artificially) includes commas (",") as digit separators. The encoding includes
  these separators in the spacing attribute value, along non-ASCII
  values. </p>
- 
- <blockquote>
- <img src="image/em-mult-carries.png" alt="\begin{array}{r}  {}_1 {\hspace{0.05em}}_1\phantom{0} \\  {}_1 {\hspace{0.05em}}_1\phantom{0} \\   1,234 \\   \times 4,321 \\   \hline  {}_1 \phantom{,} {\hspace{0.05em \,}}_1 {\hspace{0.05em}}_1  {\hspace{0.05em}}_1 \phantom{,} {\hspace{0.05em \,}}_1 \phantom{00} \\   1,234 \\   24,68\phantom{0} \\   370,2\phantom{00} \\   4,936\phantom{,000} \\   \hline   5,332,114 \end{array}"/>
- </blockquote>
  
  <div class="example mathml mml4p">
   <pre>
@@ -9309,7 +9281,10 @@
       &lt;mn&gt;5,332,114&lt;/mn&gt;
     &lt;/mstack&gt;
  </pre>
- </div>
+  <!-- <blockquote>
+   <img src="image/em-mult-carries.png" alt="\begin{array}{r}  {}_1 {\hspace{0.05em}}_1\phantom{0} \\  {}_1 {\hspace{0.05em}}_1\phantom{0} \\   1,234 \\   \times 4,321 \\   \hline  {}_1 \phantom{,} {\hspace{0.05em \,}}_1 {\hspace{0.05em}}_1  {\hspace{0.05em}}_1 \phantom{,} {\hspace{0.05em \,}}_1 \phantom{00} \\   1,234 \\   24,68\phantom{0} \\   370,2\phantom{00} \\   4,936\phantom{,000} \\   \hline   5,332,114 \end{array}"/>
+  </blockquote> -->
+</div>
  
  </section>
  
@@ -9468,6 +9443,9 @@
       &lt;/msgroup&gt;
     &lt;/mlongdiv&gt;
  </pre>
+  <!-- <blockquote>
+   <img src="image/em-longdiv-us.png" alt=""/>
+  </blockquote> -->
  </div>
  
  <p>
@@ -9512,6 +9490,9 @@
       &lt;/mlongdiv&gt;
     &lt;/mstyle&gt;
  </pre>
+  <!-- <blockquote>
+   <img src="image/em-longdiv-arabic-lefttop.png" alt=""/>
+  </blockquote> -->
  </div>
  
  </section>
@@ -9537,10 +9518,10 @@
       &lt;mn&gt; 0.3333 &lt;/mn&gt;
     &lt;/mstack&gt;
  </pre>
+  <!-- <blockquote>
+   <img src="image/repeat1.png" alt="0.33333 \overline{3}"/>
+  </blockquote> -->
  </div>
- <blockquote>
- <img src="image/repeat1.png" alt="0.33333 \overline{3}"/>
- </blockquote>
  
  <div class="example mathml mml4p">
   <pre>
@@ -9549,10 +9530,10 @@
       &lt;mn&gt; 0.142857 &lt;/mn&gt;
     &lt;/mstack&gt;
  </pre>
+ <!-- <blockquote>
+  <img src="image/repeat2.png" alt="0.\overline{142857}"/>
+ </blockquote> -->
  </div>
- <blockquote>
- <img src="image/repeat2.png" alt="0.\overline{142857}"/>
- </blockquote>
 
  <div class="example mathml mml4p">
   <pre>
@@ -9561,10 +9542,10 @@
       &lt;msline length="6"/&gt;
     &lt;/mstack&gt;
  </pre>
+ <!-- <blockquote>
+  <img src="image/repeat3.png" alt="0.\underline{142857}"/>
+ </blockquote> -->
  </div>
- <blockquote>
- <img src="image/repeat3.png" alt="0.\underline{142857}"/>
- </blockquote>
  
  <div class="example mathml mml4p">
   <pre>
@@ -9573,10 +9554,10 @@
       &lt;mn&gt; 0.142857 &lt;/mn&gt;
     &lt;/mstack&gt;
   </pre>
- </div> 
- <blockquote>
- <img src="image/repeat4.png" alt="0.\dot{1}4285\dot{7}"/>
- </blockquote>
+  <!-- <blockquote>
+    <img src="image/repeat4.png" alt="0.\dot{1}4285\dot{7}"/>
+  </blockquote> -->
+   </div> 
  
  </section>
  </section>


### PR DESCRIPTION
Moved images to inside the `<div class="example mathml mml4p">`.

They are currently commented out but potentially they can be uncommented and used in the non respec version.