### PR TITLE
[Intent grammar] readability touchup, restricted numbers

### DIFF
--- a/src/mixing.html
+++ b/src/mixing.html
@@ -103,12 +103,15 @@ the user and agent.</p>
 
    <p>The <code class="attribute">intent</code>, after ignoring white
    space between tokens, should match the following grammar.</p>
-   
+
 <pre class="def bnf">
-intent   := numlit | NCName | argref | funcall
-funcall  := (NCName | argref | funcall) '(' ( intent (',' intent )* )? ')'
-numlit   := '-'? (digit+ '.'? digit* | '.' digit+)
-argref   := '$' NCName
+intent      := name | number | reference | application
+name        := NCName
+number      := '-'? digit+ ( '.' digit+ )?
+reference   := '$' NCName
+application := function '(' arguments? ')'
+function    := name | reference | application
+arguments   := intent ( ',' intent )*
 </pre>
 
 <p>Here <a href="https://www.w3.org/TR/REC-xml-names/#NT-NCName"><code>NCName</code></a>
@@ -120,14 +123,14 @@ is as defined in  in [[xml-names]], and <code>digit</code> is a character in the
  <section>
   <h3 id="mixing_intent_examples">Intent Examples</h3>
 
-  
+
  <section>
   <h4 id="mixing_intent_examples_notation">Ambiguous Notation</h4>
 
   <p>A primary use for <code class="attribute">intent</code> is to
   disambiguate cases where the same syntax is used for different meanings,
   and typically has different readings.</p>
-  
+
 <p>Superscript, <code class="element">msup</code>, may represent a power, a transpose,
 a derivative or an embellished symbol. These cases would be distinguished as follows:</p>
 
@@ -187,7 +190,7 @@ a derivative or an embellished symbol. These cases would be distinguished as fol
   <p>A special case of ambiguous notation is the re-use of standard
   notation with meaning that may be specific to a subject area or even an
   individual document,</p>
-  
+
 <div class="example mathml mmlcore">
 <pre>
 &lt;msub intent="bell-number($index)"&gt;
@@ -205,10 +208,10 @@ a derivative or an embellished symbol. These cases would be distinguished as fol
 <code>bell-number</code> intent which is not in the <q>[^core^]</q>
 dictionary but is in the  <q>[^open^]</q> dictionary of more advanced or specialist
 topics.</p>
- 
+
  </section>
 
- 
+
  <section>
   <h4 id="mixing_intent_examples_mtr">Tables</h4>
 <div class="issue"  data-number="337"></div>
@@ -303,7 +306,7 @@ topics.</p>
 </div>
  </section>
  </section>
- 
+
  </section>
 
  <section>
@@ -1055,7 +1058,7 @@ topics.</p>
      <p>within the <code class="element">semantics</code> element</p>
     </li>
    </ol>
-   
+
    <p>
     Any other presentation markup occurring within content markup is a
     MathML error.  More detailed discussion of these three cases follows:
@@ -1318,5 +1321,3 @@ topics.</p>
 </section>
 </section>
 </section>
-
-


### PR DESCRIPTION
We had productive consensus in the meeting on June 9th about extending the intent grammar with empty arguments and higher-order applications, as seen in  [David's commit](https://github.com/w3c/mathml/commit/a2a141de31cccb37582df98b6f02d7a174685df7) shortly after.

I was traveling, so couldn't contribute much as to the specific grammar aesthetics. Trying that with this PR here, motivated by:
 * trying to avoid abbreviations that may be hard to interpret by novices
   * finding meaningful names that aren't misleading is hard in general. Still, I took some inspiration from [lambda calculus](https://en.wikipedia.org/wiki/Lambda_calculus) naming, and replaced the "funcall" abbreviation with the single word "application".
   * similarly, I moved the emphasis for `argref` to the full word `reference` since we have a single reference, but confusingly two possible understandings of the word `argument` -- one for the `arg` attribute, another for the argument slot in an "intent expression".
   * last, I added a level of indirection to `NCName` and explicitly called it `name`, to convey it's really meant for naming concepts. I was torn between `name` and `concept`. In the end I went with the less committal word.
 * trying to avoid grammar syntax that may be hard to interpret by novices
    * for example the snippet `... ) '(' ( ...` is clear to an expert, but not immediately to a novice.
    * sadly, the trade-off for making individual rules simple is that we need more rules added in. David had me concede that the usability metric here shouldn't be "smallest possible grammar", so I tried to see if a couple of extra rules won't make the "applications" a little more obvious to read through.
    * With the PR, the grammar conveys directly that "an application is a function applied to a list of arguments". I think that may be a little better?

I also snuck in my preference for numbers being rigid (i.e. no leading or trailing decimal dots), since the alternative got added in a somewhat similar fashion. This ultimately depends on the resolution of #376 .

Can discuss and change as we see fit, but thought I would at least propose this perspective.