### PR TITLE
[intent grammar] variant without numeric literals

### DIFF
--- a/src/mixing.html
+++ b/src/mixing.html
@@ -105,17 +105,15 @@ the user and agent.</p>
    space between tokens, should match the following grammar.</p>
 
 <pre class="def bnf">
-intent      := name | number | reference | application
+intent      := name | reference | application
 name        := NCName
-number      := '-'? digit+ ( '.' digit+ )?
 reference   := '$' NCName
-application := function '(' arguments? ')'
-function    := name | reference | application
+application := intent '(' arguments? ')'
 arguments   := intent ( ',' intent )*
 </pre>
 
 <p>Here <a href="https://www.w3.org/TR/REC-xml-names/#NT-NCName"><code>NCName</code></a>
-is as defined in  in [[xml-names]], and <code>digit</code> is a character in the range 0–9.</p>
+is as defined in  in [[xml-names]].</p>
   </section>
 
 


### PR DESCRIPTION
Given the latest discussion in #376 , I believe I have lost what alignment I had with the group w.r.t numeric literals from the June 9th meeting.

As such, my only constructive suggestion is to avoid grammatically modeling numeric literals until a later date, which is what this PR enacts, simplifying the `application` rule respectively.

My understanding is that currently this is solely my own preference, so I don't expect a merge. Still, I wanted to make the suggestion clear.

In my own estimation, deferring numeric literals to a later release would still allow us to reap most of the benefit of having an intent attribute, and would give us time to properly collect and design for the cases where literal values are unavoidable.