### PR TITLE
simplify intent grammar, dropping restriction on head of application

### DIFF
--- a/index.html
+++ b/index.html
@@ -206,6 +206,13 @@
                    "href": "https://w3c.github.io/mathml-docs/notes-on-mathml/"
   },
 			  
+  "MathML-AAM": {"title": "MathML Accessiblity API Mappings 1.0",
+                   "publisher": "W3C",
+                 "editors": ["Joanmarie Diggs", "Alexander Surkov", "Michael Cooper"],
+                   "status": "ED",
+                   "href": "https://w3c.github.io/mathml-aam/"
+  },
+			  
   "MathML-Media-Types": {"title": "MathML Media-type Declarations",
                    "publisher": "W3C",
                    "editors": ["Paul Libbrecht"],

--- a/src/accessibility.html
+++ b/src/accessibility.html
@@ -76,15 +76,13 @@
 
    <section>
     <h5 id="acc_aria">ARIA processing </h5>
-    <p>[Points to
-    MathML Accessibility API Mappings 1.0 [<a
-    href="https://w3c.github.io/mathml-aam/">https://w3c.github.io/mathml-aam/</a>]
-    &quot;This specification is intended for user agent developers
+    <p>Points to [[[MathML-AAM]]]
+    <q>This specification is intended for user agent developers
     responsible for MathML accessibility in their product. The goal of
     this specification is to maximize the accessibility of MathML
     content by ensuring each assistive technology receives MathML
     content with the roles, states, and properties it
-    expects.&quot;</p> <p>[Needs to be fleshed out...]</p>
+    expects.</q></p> <p>[Needs to be fleshed out...]</p>
    </section>
 
    

--- a/src/mixing.html
+++ b/src/mixing.html
@@ -109,8 +109,7 @@ intent      := name | number | reference | application
 name        := NCName
 number      := '-'? digit+ ( '.' digit+ )?
 reference   := '$' NCName
-application := function '(' arguments? ')'
-function    := name | reference | application
+application := intent '(' arguments? ')'
 arguments   := intent ( ',' intent )*
 </pre>
 


### PR DESCRIPTION
The original subject of issue #376, the syntax for numeric literals, was decided in the WG call on 2022-06-23, however most of the recent discussion in that issue has been on whether to allow the head of a function call to be an unrestricted intent, or a restricted form not allowing a numeric literal.

@dginev  argued for keeping the restriction, I, @NSoiffer  and @brucemiller  argued (I think) for dropping the restriction and simplifyig the grammar to recursively call `intent` rather than have the extra `function` production which omits numeric literals.

To make sure we are all talking about the same change, this PR  makes explicit the suggested grammar
