### PR TITLE
more text on silent hint and underscore

### DIFF
--- a/src/mixing.html
+++ b/src/mixing.html
@@ -298,13 +298,42 @@
 
      <li><code>semi-factorial @postfix($x)</code> would be read as <q>x semi factorial</q></li>
 
-     <li><code>free-algebra ($r, $x)</code> would be read as <q>free algebra of r and x</q></li>
-     
-     <li><code>free-algebra-construct@silent (free, $r, algebra-on, $x)</code> would be read as <q>free, r algebra on x</q></li>
-
-
     </ul>
 
+    <p>In most cases it is preferable to use an <code
+    class="attribute">intent</code> that accurately reflects the
+    mathematical structure of the expression. This allows the intent
+    to be used while navigating that structure, and also, for concepts
+    known in the Concept dictionary being used by the application, it allows
+    translated, locale-specific text to be generated.</p>
+    <p>However, as the default reading of an unknown name is to read
+    the name, after splitting on <code>._-</code> as described above,
+    it is possible to provide readings that do not match the prefix
+    functional structure. It should be noted that such uses of  <code
+    class="attribute">intent</code> may prevent other uses of the
+    attribute, for example as an aid to inferring the mathematical
+    structure for conversions to Content MathML or computational software
+    systems. The <code>@silent</code> hint may be especially
+    useful for these use cases.
+    </p>
+    <p>For example:</p>
+    
+    <ul>
+     <li><code>free-algebra ($r, $x)</code><br/> would be read as <q>free algebra of r and x</q></li>
+     
+     <li><code>free-algebra-construct@silent (_free, $r, _algebra, _on, $x)</code><br/> would be read as <q>free r algebra on x</q></li>
+
+    </ul>
+    <p>Here using <code>@silent</code> avoids the default prefix
+    reading, and allows additional names to be added to the argument
+    list to generate the specified words interspersed with the
+    references to the mathematical arguments. It is recommended that
+    Names added purely to generate text, and not corresponding to a
+    mathematical argument, start with <code>_</code> (U+005F).
+    This does not affect the text generated, but may aid other systems
+    in ignoring these terms while interpreting the  <code
+    class="attribute">intent</code>.</p>
+    
    </section>
    
    <section>

--- a/src/mixing.html
+++ b/src/mixing.html
@@ -137,6 +137,9 @@
      If the speech hints are not being used
      and the literal concept name is being read then each of  `-`, `_` and `.` should be
      read as an inter-word space.</p>
+     <p>Names starting with <q>`-`</q> (U+002D) will never be in the
+     Concept dictionary used by the application, so may be used to
+     ensure aliteral text interpretation.</p>
     </dd>
     <dt><dfn data-dfn-for="intent" id="intent_number">number</dfn></dt>
     <dd>
@@ -330,7 +333,8 @@
     references to the mathematical arguments. It is recommended that
     Names added purely to generate text, and not corresponding to a
     mathematical argument, start with <code>_</code> (U+005F).
-    This does not affect the text generated, but may aid other systems
+    This ensures the name is not in the Concept Dictionary used by the
+    application, so will be taken as literal text. It may also  aid other systems
     in ignoring these terms while interpreting the  <code
     class="attribute">intent</code>.</p>
     

--- a/src/mixing.html
+++ b/src/mixing.html
@@ -139,7 +139,7 @@
      read as an inter-word space.</p>
      <p>Names starting with <q>`-`</q> (U+002D) will never be in the
      Concept dictionary used by the application, so may be used to
-     ensure aliteral text interpretation.</p>
+     ensure a literal text interpretation.</p>
     </dd>
     <dt><dfn data-dfn-for="intent" id="intent_number">number</dfn></dt>
     <dd>

--- a/src/mixing.html
+++ b/src/mixing.html
@@ -322,10 +322,14 @@
     <p>For example:</p>
     
     <ul>
-     <li><code>free-algebra ($r, $x)</code><br/> would be read as <q>free algebra of r and x</q></li>
+     <li><code>free-algebra ($r, $x)</code><br/>
+     would be read as <q>free algebra of r and x</q></li>
      
-     <li><code>free-algebra-construct@silent (_free, $r, _algebra, _on, $x)</code><br/> would be read as <q>free r algebra on x</q></li>
+     <li><code>free-algebra-construct@silent (_free, $r, _algebra, _on, $x)</code><br/>
+      would be read as <q>free r algebra on x</q></li>
 
+      <li><code>_(free, _($r,algebra), on, $x)</code><br/>
+      would be read as <q>free r algebra; on x</q></li>
     </ul>
     <p>Here using <code>@silent</code> avoids the default prefix
     reading, and allows additional names to be added to the argument
@@ -336,7 +340,13 @@
     This ensures the name is not in the Concept Dictionary used by the
     application, so will be taken as literal text. It may also  aid other systems
     in ignoring these terms while interpreting the  <code
-    class="attribute">intent</code>.</p>
+    class="attribute">intent</code>.
+    As shown in the last example, rather than using
+    <code>@silent</code>, it is possible to use an anonymousfunction head
+    such as <code>_</code> would read as a space, so naturally silent. An
+    intent in this form loses the uses of intent to supply the
+    functional structure but may be used to give fine control over
+    generated readings.</p>
     
    </section>
    


### PR DESCRIPTION
Possible text as discussed in #398  warning about possible downsides of forcing text and describing a (weak form of) the `_` prefix just as a posible naming  convention you might want to follow.

HTML view at

https://davidcarlisle.github.io/mathml/#mixing_intent_examples_hint

(only that section changed)
