### PR TITLE
pubrules security and privacy sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -193,7 +193,10 @@
      edDraftURI:    "https://w3c.github.io/mathml/",
      shortName:     "MathML4",
      canonicalURI: "TR",
-     maxTocLevel:   4,
+       maxTocLevel:   4,
+       lint: {
+	   "required-sections":false
+       },
      otherLinks:    [{
      key: "Latest MathML Recommendation",
      data: [{
@@ -485,8 +488,6 @@ div.issue > *:nth-child(2) {display:block;}
   <section data-include="src/operator-dict.html" data-include-replace="true"></section>
   <section data-include="src/accessibility.html" data-include-replace="true"></section>
   <section data-include="src/conformance.html" data-include-replace="true"></section>
-  <section data-include="src/security.html" data-include-replace="true"></section>
-  <section data-include="src/privacy.html" data-include-replace="true"></section>
   <section data-include="src/contm-ops.html" data-include-replace="true"></section>
   <section data-include="src/transform2strict.html" data-include-replace="true"></section>
   <section data-include="src/mmlindex.html" data-include-replace="true"></section>

--- a/index.html
+++ b/index.html
@@ -485,6 +485,8 @@ div.issue > *:nth-child(2) {display:block;}
   <section data-include="src/operator-dict.html" data-include-replace="true"></section>
   <section data-include="src/accessibility.html" data-include-replace="true"></section>
   <section data-include="src/conformance.html" data-include-replace="true"></section>
+  <section data-include="src/security.html" data-include-replace="true"></section>
+  <section data-include="src/privacy.html" data-include-replace="true"></section>
   <section data-include="src/contm-ops.html" data-include-replace="true"></section>
   <section data-include="src/transform2strict.html" data-include-replace="true"></section>
   <section data-include="src/mmlindex.html" data-include-replace="true"></section>

--- a/src/conformance.html
+++ b/src/conformance.html
@@ -316,6 +316,7 @@
       <h3 id="security">Privacy and Security Considerations</h3>
       <p>Web platform implementations of MathML should implement [[MathML-Core]],
 	and so the <a href="https://www.w3.org/TR/mathml-core/#security-considerations">Security Considerations</a> and <a href="https://www.w3.org/TR/mathml-core/privacy-considerations">Privacy Considerations</a>  specified there apply.</p>
+      <p>In some situations, MathML expressions can be parsed as XML. The security considerations of XML parsing apply then as explained in [[?RFC7303]].
     </section>
     
 

--- a/src/conformance.html
+++ b/src/conformance.html
@@ -311,4 +311,13 @@
    judiciously.</p>
 
   </section>
+
+      <section class="appendix informative">
+      <h3 id="security">Privacy and Security Considerations</h3>
+      <p>Web platform implementations of MathML should implement [[MathML-Core]],
+	and so the <a href="https://www.w3.org/TR/mathml-core/#security-considerations">Security Considerations</a> and <a href="https://www.w3.org/TR/mathml-core/privacy-considerations">Privacy Considerations</a>  specified there apply.</p>
+    </section>
+    
+
+  
  </section>

--- a/src/privacy.html
+++ b/src/privacy.html
@@ -1,0 +1,6 @@
+    <section class="appendix informative">
+      <h2 id="privacy">Privacy Considerations</h2>
+      <p>Web platform implementations of MathML should implement [[MathML-Core]],
+	and so the <a href="https://www.w3.org/TR/mathml-core/privacy-considerations">Privacy Considerations</h2></a>  specified there apply.</p>
+    </section>
+    

--- a/src/privacy.html
+++ b/src/privacy.html
@@ -1,6 +1,6 @@
     <section class="appendix informative">
       <h2 id="privacy">Privacy Considerations</h2>
       <p>Web platform implementations of MathML should implement [[MathML-Core]],
-	and so the <a href="https://www.w3.org/TR/mathml-core/privacy-considerations">Privacy Considerations</h2></a>  specified there apply.</p>
+	and so the <a href="https://www.w3.org/TR/mathml-core/privacy-considerations">Privacy Considerations</a>  specified there apply.</p>
     </section>
     

--- a/src/security.html
+++ b/src/security.html
@@ -1,0 +1,6 @@
+    <section class="appendix informative">
+      <h2 id="security">Security Considerations</h2>
+      <p>Web platform implementations of MathML should implement [[MathML-Core]],
+	and so the <a href="https://www.w3.org/TR/mathml-core/#security-considerations">Security Considerations</a>  specified there apply.</p>
+    </section>
+    


### PR DESCRIPTION
Changing the class from ED to FPWD triggered some extra checks from respec and pubrules, and both wanted security and privacy considerations sections.

This PR adds appendices with the required names with initial text just referencing the matching sections in mathml-core. We could add more specific text if required later, but opening a PR to log a decision to add or not these sections as appendices.


