### PR TITLE
Underscore examples for language-near intent values

### DIFF
--- a/src/mixing.html
+++ b/src/mixing.html
@@ -298,18 +298,19 @@
 <blockquote>x prime<br/> x superscript prime end superscript</blockquote>
 </div>
 
-<p>Language-near intent values can also be annotated compositionally, via the underscore function.</p>
+<p>Custom accessible descriptions, such as author-preferred variable or operator names, can also be annotated compositionally, via the underscore function.</p>
+<p>The above notation could instead intend the custom name "x-new", which we can mark with a single literal `intent="x-new"`, or as a compound narration of two arguments:</p>
 <div class="example mathml mmlcore">
 <pre>
 &lt;msup intent="_($base,$script)">
   &lt;mi arg="base">x&lt;/mi>
-  &lt;mo arg="script" intent="_prime">&#x2032;&lt;/mo>
+  &lt;mo arg="script" intent="_new">&#x2032;&lt;/mo>
 &lt;/msup>
 </pre>
-<blockquote>x prime</blockquote>
+<blockquote>x new<br>x superscript prime end superscript</blockquote>
 </div>
 
-<p>Chunking may also be a clear style for cases where fragments are explicitly localized. A cyrillic (Bulgarian) example:</p>
+<p>Using the underscore function may also add clarity when the fragments of a compound name are explicitly localized. A cyrillic (Bulgarian) example:</p>
 <div class="example mathml mmlcore">
 <pre>
 &lt;msup intent="_($base,$script)">
@@ -317,10 +318,10 @@
   &lt;mo arg="script" intent="_прим">&#x2032;&lt;/mo>
 &lt;/msup>
 </pre>
-<blockquote>хикс прим</blockquote>
+<blockquote>хикс прим<br/>x superscript prime end superscript</blockquote>
 </div>
 
-<p>Alternatively, when supported, localization of fragments could be delegated to AT:</p>
+<p>Alternatively, the narration of individual fragments could be fully delegated to AT, while still specifying their grouping:</p>
 <div class="example mathml mmlcore">
 <pre>
 &lt;msup intent="_($base,$script)">

--- a/src/mixing.html
+++ b/src/mixing.html
@@ -47,7 +47,7 @@
   simple functional syntax representing the intended speech.
   A formal grammar is given below, but a typical example would be
   <code>intent="power($base,$exponent)"</code> used in a context such as:</p>
-  
+
   <div class="example mathml mmlcore">
    <pre>
     &lt;msup intent="power($base,$exp)">
@@ -213,7 +213,7 @@
       AT should always produce speech that is appropriate to the community they serve.</li>
       <li><dfn id="intent-open">Open</dfn>: This is an open list of concepts
       to which contributions are invited.
-      AT reading MathML attributed with a name in this list 
+      AT reading MathML attributed with a name in this list
       MAY use the speech hints provided by the intent
       definition but a system
       may also fall back on reading the identifier name as given.
@@ -254,7 +254,7 @@
 </pre>
 <blockquote>x to the n-th power<br/> x superscript n end superscript</blockquote>
 </div>
-<p>An alternative default rendering without intent would be to assume that 
+<p>An alternative default rendering without intent would be to assume that
   <code class="element">msup</code> is always a power, so the second rendering above
   might also be <q>x to the n-th power</q>. In that case the second renderings below
   will (incorrectly) speak the examples using <q>raised to the ... power</q>.
@@ -298,7 +298,39 @@
 <blockquote>x prime<br/> x superscript prime end superscript</blockquote>
 </div>
 
-    <p>Similarly an over bar may represent complex conjugation, or mean (average), again with possible readings with and without <code class="attribute">intent</code>:</p>
+<p>Language-near intent values can also be annotated compositionally, via the underscore function.</p>
+<div class="example mathml mmlcore">
+<pre>
+&lt;msup intent="_($base,$script)">
+  &lt;mi arg="base">x&lt;/mi>
+  &lt;mo arg="script" intent="_prime">&#x2032;&lt;/mo>
+&lt;/msup>
+</pre>
+<blockquote>x prime</blockquote>
+</div>
+
+<p>Chunking may also be a clear style for cases where fragments are explicitly localized. A cyrillic (Bulgarian) example:</p>
+<div class="example mathml mmlcore">
+<pre>
+&lt;msup intent="_($base,$script)">
+  &lt;mi arg="base" intent="_хикс">x&lt;/mi>
+  &lt;mo arg="script" intent="_прим">&#x2032;&lt;/mo>
+&lt;/msup>
+</pre>
+<blockquote>хикс прим</blockquote>
+</div>
+
+<p>Alternatively, when supported, localization of fragments could be delegated to AT:</p>
+<div class="example mathml mmlcore">
+<pre>
+&lt;msup intent="_($base,$script)">
+  &lt;mi arg="base">x&lt;/mi>
+  &lt;mo arg="script">&#x2032;&lt;/mo>
+&lt;/msup>
+</pre>
+</div>
+
+    <p>An overbar may represent complex conjugation, or mean (average), again with possible readings with and without <code class="attribute">intent</code>:</p>
 
  <div class="example mathml mmlcore">
 <pre>
@@ -312,7 +344,7 @@
   &lt;mo&gt;&amp;#xaf;&lt;/mo&gt;
 &lt;/mover&gt;
 </pre>
-    
+
      <blockquote>conjugate of z is not  mean of X<br/>
      z with bar above  is not  X with bar above</blockquote>
     </div>
@@ -331,7 +363,7 @@
      <blockquote>bell number of 2</blockquote>
     </div>
    </section>
-   
+
    <section>
     <h4 id="mixing_intent_warning">A Warning about [=literal=] and [=hint=]</h4>
     <p>The [=literal=] and [=hint=] features extend the coverage of mathematical concepts
@@ -347,7 +379,7 @@
     <ul>
      <li><code>free-algebra ($r, $x)</code><br/>
      would be read as <q>free algebra of r and x</q></li>
-     
+
      <li><code>free-algebra-construct@silent (_free, $r, _algebra, _on, $x)</code><br/>
       would be read as <q>free r algebra on x</q></li>
 
@@ -361,7 +393,7 @@
      Thus, the last two examples would be discouraged.
     </p>
    </section>
-   
+
    <section>
      <h4 id="mixing_intent_examples_mtr">Tables</h4>
      <div class="ednote">
@@ -378,7 +410,7 @@
        grammar or to the terms in the Core Concept dictionary of intent
        terms. Discussions are taking place in the following two GitHub
        Issues.</p>
-       
+
      </div>
 
        <p class="issue" data-number="337">Issue 337</p>


### PR DESCRIPTION
Fixes #422 .

Adding some examples for using the underscore function to build up language-near descriptions in the intent values, as per [my comment in #422](https://github.com/w3c/mathml/issues/422#issuecomment-1244171833). 

I stopped short of recommending a certain style is _better_, since there is usually a qualifier of "better if you are in context X and want to achieve benefit Y". That could probably one day be a note of some sort.

But I introduced some visual effects that I am already unhappy about - my local rendering shows a whole screen of centered x primes, which can be a bit disorienting.

I ended up making the branch in the main repository, so no live gh-pages preview - apologies. You'll have to do a checkout and run `jekyll serve` locally to see the changes.