### PR TITLE
Intent properties

### DIFF
--- a/src/mixing.html
+++ b/src/mixing.html
@@ -69,7 +69,7 @@
    <p>The value of the <code class="attribute">intent</code> attribute, should match the following grammar.</p>
 
    <pre class="def bnf">
-intent             := term property* hint? | property+ hint? | application 
+intent             := S ( term property* hint? | property+ hint? | application ) S 
 term               := concept-or-literal | number | reference 
 concept-or-literal := NCName
 number             := '-'? digit+ ( '.' digit+ )?
@@ -244,6 +244,23 @@ S                  := [ \t\n\r]*
      read as an inter-word space.</p>
   </section>
 
+  <section>
+   <h4 id="mixing_intent_self">Intent Self References</h4>
+   <p>The grammar allows the intent to omit the leading <i>term</i>
+   and just consist of a non-empty list of properties. This should be
+   interpreted as specfying properties for the current element. This
+   can be a useful technique, especially for large constructs such as tables as
+   it allows the children to be inferred without needing to be
+   explicitly referenced in the `intent` as would be the case with an
+   <i>applicaton</i>.
+   For example, `&lt;mtable intent=":array">...` might read the table as
+   an array of values, and `&lt;mtable intent=":aligned-equations">...`
+   might read the table in a style more appropriate for a list of
+   equations. In both cases the navigation of the underlying table
+   structure can be supplied by the AT system, as it would for an
+   un-annotated table.</p>
+  </section>
+  
   <section>
    <h4 id="mixing_intent_errors">Intent Error Handling</h4>
    <p>An intent processor may report errors in intent expressions in

--- a/src/mixing.html
+++ b/src/mixing.html
@@ -266,8 +266,8 @@ S                  := [ \t\n\r]*
    <p>An intent processor may report errors in intent expressions in
    any appropriate way, including returning a message as the
    generated text, or throwing an exception (error) in whatever form
-   the implementation supports. However in  web platform context it is
-   often not appropriate to report errors to the readers who have no
+   the implementation supports. However in  web platform contexts it is
+   often not appropriate to report errors to the reader who has no
    access to correct the source, so intent procesors should offer a
    mode which recovers from errors as described below.</p>
    <section>

--- a/src/mixing.html
+++ b/src/mixing.html
@@ -290,7 +290,38 @@ S                  := [ \t\n\r]*
    </section>
   </section>
     
-  <section>
+
+   <section>
+    <h4 id="mixing_intent_warning">A Warning about [=literal=] and [=hint=]</h4>
+    <p>The [=literal=] and [=hint=] features extend the coverage of mathematical concepts
+    beyond the predefined dictionaries and allow expression of speech preferences.
+    For example, when `$x` and `$y` reference `&lt;mi arg="x">x&lt;/mi>` and `&lt;mi
+     arg="y">y&lt;/mi>` respectively, then</p>
+    <ul>
+     <li><code>list @silent ($x,$y)</code> would be read as <q>x y</q></li>
+     <li><code>semi-factorial @postfix($x)</code> would be read as <q>x semi factorial</q></li>
+    </ul>
+    <p>These features also allow taking almost complete control of the generated speech.
+    For example, compare:</p>
+    <ul>
+     <li><code>free-algebra ($r, $x)</code><br/>
+     would be read as <q>free algebra of r and x</q></li>
+
+     <li><code>free-algebra-construct@silent (_free, $r, _algebra, _on, $x)</code><br/>
+      would be read as <q>free r algebra on x</q></li>
+
+      <li><code>_(free, _($r,algebra), on, $x)</code><br/>
+      would be read as <q>free r algebra; on x</q></li>
+    </ul>
+    <p>However, since the literals are not in dictionaries,
+     the meaning behind the expressions become more opaque,
+     and thus excessive use of these features will tend to limit the AT's ability
+     to adapt to the needs of the user, as well as limit translation and locale-specific speech.
+     Thus, the last two examples would be discouraged.
+    </p>
+   </section>
+
+   <section>
    <h4 id="mixing_intent_examples">Intent Examples</h4>
 
     <p>A primary use for <code class="attribute">intent</code> is to
@@ -418,40 +449,10 @@ S                  := [ \t\n\r]*
      <p>will still produce the expected reading:</p>
      <blockquote>bell number of 2</blockquote>
     </div>
-   </section>
 
+    
    <section>
-    <h4 id="mixing_intent_warning">A Warning about [=literal=] and [=hint=]</h4>
-    <p>The [=literal=] and [=hint=] features extend the coverage of mathematical concepts
-    beyond the predefined dictionaries and allow expression of speech preferences.
-    For example, when `$x` and `$y` reference `&lt;mi arg="x">x&lt;/mi>` and `&lt;mi
-     arg="y">y&lt;/mi>` respectively, then</p>
-    <ul>
-     <li><code>list @silent ($x,$y)</code> would be read as <q>x y</q></li>
-     <li><code>semi-factorial @postfix($x)</code> would be read as <q>x semi factorial</q></li>
-    </ul>
-    <p>These features also allow taking almost complete control of the generated speech.
-    For example, compare:</p>
-    <ul>
-     <li><code>free-algebra ($r, $x)</code><br/>
-     would be read as <q>free algebra of r and x</q></li>
-
-     <li><code>free-algebra-construct@silent (_free, $r, _algebra, _on, $x)</code><br/>
-      would be read as <q>free r algebra on x</q></li>
-
-      <li><code>_(free, _($r,algebra), on, $x)</code><br/>
-      would be read as <q>free r algebra; on x</q></li>
-    </ul>
-    <p>However, since the literals are not in dictionaries,
-     the meaning behind the expressions become more opaque,
-     and thus excessive use of these features will tend to limit the AT's ability
-     to adapt to the needs of the user, as well as limit translation and locale-specific speech.
-     Thus, the last two examples would be discouraged.
-    </p>
-   </section>
-
-   <section>
-     <h4 id="mixing_intent_examples_mtr">Tables</h4>
+     <h5 id="mixing_intent_examples_mtr">Tables</h5>
      <div class="ednote">
        <p>The <code class="element">&lt;mtable&gt;</code> element is
        used in many ways, for denoting matrices, systems of equations,
@@ -562,6 +563,9 @@ S                  := [ \t\n\r]*
 </pre>
     </div>
    </section>
+   </section>
+
+
 
  </section>
 

--- a/src/mixing.html
+++ b/src/mixing.html
@@ -76,8 +76,8 @@ number             := '-'? digit+ ( '.' digit+ )?
 reference          := '$' NCName
 application        := intent S '(' S arguments? S ')'
 arguments          := intent ( S ',' S intent )*
-property           := S ':' S NCName
-hint               := S '@' S ( 'prefix' | 'infix' | 'postfix' | 'function' | 'silent' )
+property           := S ':' NCName
+hint               := S '@' ( 'prefix' | 'infix' | 'postfix' | 'function' | 'silent' )
 S                  := [ \t\n\r]*
    </pre>
 

--- a/src/mixing.html
+++ b/src/mixing.html
@@ -70,13 +70,16 @@
    space between tokens, should match the following grammar.</p>
 
    <pre class="def bnf">
-    intent             := concept-or-literal | number | reference | application
-    concept-or-literal := NCName
-    number             := '-'? digit+ ( '.' digit+ )?
-    reference          := '$' NCName
-    application        := intent hint? '(' arguments? ')'
-    arguments          := intent ( ',' intent )*
-    hint               := '@' ( 'prefix' | 'infix' | 'postfix' | 'function' | 'silent' )
+intent             := term property* hint? | property+ hint? | application 
+term               := concept-or-literal | number | reference 
+concept-or-literal := NCName
+number             := '-'? digit+ ( '.' digit+ )?
+reference          := '$' NCName
+application        := intent S '(' S arguments? S ')'
+arguments          := intent ( S ',' S intent )*
+property           := S ':' S NCName
+hint               := S '@' S ( 'prefix' | 'infix' | 'postfix' | 'function' | 'silent' )
+S                  : [ \t\n\r]*
    </pre>
 
    <p>Here <a href="https://www.w3.org/TR/REC-xml-names/#NT-NCName"><code>NCName</code></a>
@@ -169,6 +172,13 @@
       </li>
      </ul>
     </dd>
+    <dt><dfn id="intent_hint">property</dfn></dt>
+    <dd>
+     A [=property=] annotates the concept name with additional
+     properties such as `:unit` or `:chemistry` which may be used by
+     the system to adjust the generated speech or Braille in system
+     specifc ways.
+    </dd>
    </dl>
   </section>
 
@@ -235,6 +245,35 @@
      read as an inter-word space.</p>
   </section>
 
+  <section>
+   <h4 id="mixing_intent_errors">Intent Error Handling</h4>
+   <p>An intent processor may report errors in intent expressions in
+   any appropriate way, including returning a message as the
+   generated text, or throwing an exception (error) in whatever form
+   the implementation supports. However in  web platform context it is
+   often not appropriate to report errors to the readers who have no
+   access to correct the source, so intent procesors should offer a
+   mode which recovers from errors as described below.</p>
+   <section>
+    <h5 id="mixing_intent_error_recovery">Intent Error Recovery</h5>
+    <ol>
+     <li>If an <code class="attribute">intent</code>
+     attribute does not match the grammar <a href="#mixing_intent_grammar"></a>,
+     then the processor should act as if the attribute were not
+     present.
+     Typically this will result in a suitable fallback text being
+     generated from the MathML element and its descendents. Note that
+     just the erroneous attribute is ignored, other <code
+     class="attribute">intent</code> attributes in the MathML
+     expression should be used.</li>
+     <li>If a `reference` such as `$x` does not correspond to an <code
+     class="attribute">arg</code> attribute with value `x` on a
+     descendent element, the processor should act as if the reference
+     were replaced by the literal `_dollar_x`.</li>
+    </ol>
+   </section>
+  </section>
+    
   <section>
    <h4 id="mixing_intent_examples">Intent Examples</h4>
 
@@ -307,7 +346,7 @@
   &lt;mo arg="script" intent="_new">&#x2032;&lt;/mo>
 &lt;/msup>
 </pre>
-<blockquote>x new<br>x superscript prime end superscript</blockquote>
+<blockquote>x new<br/>x superscript prime end superscript</blockquote>
 </div>
 
 <p>Using the underscore function may also add clarity when the fragments of a compound name are explicitly localized. A cyrillic (Bulgarian) example:</p>

--- a/src/mixing.html
+++ b/src/mixing.html
@@ -74,8 +74,8 @@ term               := concept-or-literal | number | reference
 concept-or-literal := NCName
 number             := '-'? \d+ ( '.' \d+ )?
 reference          := '$' NCName
-application        := intent S '(' S arguments? S ')'
-arguments          := intent ( S ',' S intent )*
+application        := intent '(' arguments? S ')'
+arguments          := intent ( ',' intent )*
 property           := S ':' NCName
 S                  := [ \t\n\r]*
    </pre>

--- a/src/mixing.html
+++ b/src/mixing.html
@@ -69,15 +69,14 @@
    <p>The value of the <code class="attribute">intent</code> attribute, should match the following grammar.</p>
 
    <pre class="def bnf">
-intent             := S ( term property* hint? | property+ hint? | application ) S 
+intent             := S ( term property* | property+ | application ) S 
 term               := concept-or-literal | number | reference 
 concept-or-literal := NCName
-number             := '-'? digit+ ( '.' digit+ )?
+number             := '-'? \d+ ( '.' \d+ )?
 reference          := '$' NCName
 application        := intent S '(' S arguments? S ')'
 arguments          := intent ( S ',' S intent )*
 property           := S ':' NCName
-hint               := S '@' ( 'prefix' | 'infix' | 'postfix' | 'function' | 'silent' )
 S                  := [ \t\n\r]*
    </pre>
 
@@ -135,48 +134,50 @@ S                  := [ \t\n\r]*
      An <a data-link-for="intent" data-link-type="dfn" href="#intent_application">application</a>
      denotes a function applied to arguments using
      a standard prefix notation.  Optionally, between the head of the
-     function and the list of arguments there may be a [=hint=] as
-     described below to influence the style of text reading generated.
+     function and the list of arguments there may be a [=property=] as
+     described below to influence the style of text reading generated, or to
+     provide other information to any consumer of the intent.
     </dd>
 
-    <dt><dfn id="intent_hint">hint</dfn></dt>
-    <dd>
-     A [=hint=] in a function <a data-link-for="intent" data-link-type="dfn"
-     href="#intent_application">application</a> requests that
-     the reading of the name may be suppressed, or the word ordering may be affected.
-     Note that the hints <code>prefix</code>, <code>infix</code> and <code>postfix</code>
-     refer to the spoken word order of the name and arguments,
-     and <em>not</em> (necessarily) the order used in the displayed mathematical notation.
-     <ul>
-      <li>
-      In the case of a [=concept=] name, the hint MAY be used in choosing the alternatives
-      supported by the AT. For example <code>union</code> is in the
-      Core dictionary with speech patterns "$1 union $2" and "union of $1 and $2".
-      An intent <code>union @prefix ($a,$b)</code> would
-      indicate that the latter style is preferred.
-      </li>
-      <li>For [=literal=] names, the text generated from the function head SHOULD be read
-      as specified in the hint.
-     <ul>
-      <li><code>f @prefix ($x)      </code>: <q>f x</q></li>
-      <li><code>f @infix ($x,y)     </code>: <q>x f y</q></li>
-      <li><code>f @postix ($x)      </code>: <q>x f</q></li>
-      <li><code>f @function ($x, $y)</code>: <q>f of x and y</q></li>
-      <li><code>f @silent ($x,$y)   </code>: <q>x y</q></li>
-     </ul>
-      The specific words used above are only examples;
-      AT is free to choose other appropriate audio renderings.
-      For example, <code>f@function($x, $y)</code> could also be spoken as
-      <q>f of x comma y</q>.
-      </li>
-     </ul>
-    </dd>
-    <dt><dfn id="intent_hint">property</dfn></dt>
+    
+    <dt><dfn id="intent_property">property</dfn></dt>
     <dd>
      A [=property=] annotates the concept name with additional
      properties such as `:unit` or `:chemistry` which may be used by
      the system to adjust the generated speech or Braille in system
      specifc ways.
+ 
+     <p>The list of properties supported by any system but should include
+     <code>prefix</code>, <code>infix</code>, <code>postfix</code>, <code>function</code> <code>silent</code>.
+     These properties in a function <a data-link-for="intent" data-link-type="dfn"
+     href="#intent_application">application</a> request that
+     the reading of the name may be suppressed, or the word ordering may be affected.
+     Note that the properties <code>prefix</code>, <code>infix</code> and <code>postfix</code>
+     refer to the spoken word order of the name and arguments,
+     and <em>not</em> (necessarily) the order used in the displayed mathematical notation.</p>
+     <ul>
+      <li>
+      In the case of a [=concept=] name, the property MAY be used in choosing the alternatives
+      supported by the AT. For example <code>union</code> is in the
+      Core dictionary with speech patterns "$1 union $2" and "union of $1 and $2".
+      An intent <code>union :prefix ($a,$b)</code> would
+      indicate that the latter style is preferred.
+      </li>
+      <li>For [=literal=] names, the text generated from the function head SHOULD be read
+      as specified in the property.
+     <ul>
+      <li><code>f :prefix ($x)      </code>: <q>f x</q></li>
+      <li><code>f :infix ($x,y)     </code>: <q>x f y</q></li>
+      <li><code>f :postix ($x)      </code>: <q>x f</q></li>
+      <li><code>f :function ($x, $y)</code>: <q>f of x and y</q></li>
+      <li><code>f :silent ($x,$y)   </code>: <q>x y</q></li>
+     </ul>
+      The specific words used above are only examples;
+      AT is free to choose other appropriate audio renderings.
+      For example, <code>f:function($x, $y)</code> could also be spoken as
+      <q>f of x comma y</q>.
+      </li>
+     </ul>
     </dd>
    </dl>
   </section>
@@ -185,7 +186,7 @@ S                  := [ \t\n\r]*
     <h4 id="mixing_intent_dictionaries">Intent Concept Dictionaries</h4>
      <p>An <dfn>Intent Concept Dictionary</dfn> is a mapping from a [=concept=] name
       to specific speech or braille for that concept.
-      The mapping may take into account any [=hint=] that follows the name.
+      The mapping may take into account any [=property=] that follows the name.
       AT that makes use of <code class="attribute">intent</code>
       SHOULD be able to produce speech or braille that corresponds to any
       of the concepts in the [=Core=] table discussed below.
@@ -195,7 +196,7 @@ S                  := [ \t\n\r]*
       </p>
       <p>The Intent Concept Dictionary is somewhat analogous to the <a href="#oper-dict"></a> used by
       MathML renderers in that it provides a set of defaults renderers should be aware of.
-      The <code>hint</code> also has some analogies to the operator dictionary's use of
+      The <code>property</code> also has some analogies to the operator dictionary's use of
       <code class="attribute">form</code>.
     </p>
     <p class="issue" data-number="410">Issue 410</p>
@@ -292,14 +293,14 @@ S                  := [ \t\n\r]*
     
 
    <section>
-    <h4 id="mixing_intent_warning">A Warning about [=literal=] and [=hint=]</h4>
-    <p>The [=literal=] and [=hint=] features extend the coverage of mathematical concepts
+    <h4 id="mixing_intent_warning">A Warning about [=literal=] and [=property=]</h4>
+    <p>The [=literal=] and [=property=] features extend the coverage of mathematical concepts
     beyond the predefined dictionaries and allow expression of speech preferences.
     For example, when `$x` and `$y` reference `&lt;mi arg="x">x&lt;/mi>` and `&lt;mi
      arg="y">y&lt;/mi>` respectively, then</p>
     <ul>
-     <li><code>list @silent ($x,$y)</code> would be read as <q>x y</q></li>
-     <li><code>semi-factorial @postfix($x)</code> would be read as <q>x semi factorial</q></li>
+     <li><code>list :silent ($x,$y)</code> would be read as <q>x y</q></li>
+     <li><code>semi-factorial :postfix($x)</code> would be read as <q>x semi factorial</q></li>
     </ul>
     <p>These features also allow taking almost complete control of the generated speech.
     For example, compare:</p>
@@ -307,7 +308,7 @@ S                  := [ \t\n\r]*
      <li><code>free-algebra ($r, $x)</code><br/>
      would be read as <q>free algebra of r and x</q></li>
 
-     <li><code>free-algebra-construct@silent (_free, $r, _algebra, _on, $x)</code><br/>
+     <li><code>free-algebra-construct:silent (_free, $r, _algebra, _on, $x)</code><br/>
       would be read as <q>free r algebra on x</q></li>
 
       <li><code>_(free, _($r,algebra), on, $x)</code><br/>
@@ -354,10 +355,10 @@ S                  := [ \t\n\r]*
 </pre>
 <blockquote>transpose of A<br/> A superscript T end superscript </blockquote>
 </div>
-<p>However, with a hint, this example might be read differently.</p>
+<p>However, with a property, this example might be read differently.</p>
 <div class="example mathml mmlcore">
 <pre>
-&lt;msup intent="$op @postfix ($a)">
+&lt;msup intent="$op :postfix ($a)">
   &lt;mi arg="a">A&lt;/mi>
   &lt;mi arg="op" intent="transpose">T&lt;/mi>
 &lt;/msup>

--- a/src/mixing.html
+++ b/src/mixing.html
@@ -78,7 +78,7 @@ application        := intent S '(' S arguments? S ')'
 arguments          := intent ( S ',' S intent )*
 property           := S ':' S NCName
 hint               := S '@' S ( 'prefix' | 'infix' | 'postfix' | 'function' | 'silent' )
-S                  : [ \t\n\r]*
+S                  := [ \t\n\r]*
    </pre>
 
    <p>Here <a href="https://www.w3.org/TR/REC-xml-names/#NT-NCName"><code>NCName</code></a>

--- a/src/mixing.html
+++ b/src/mixing.html
@@ -66,8 +66,7 @@
   <section>
    <h4 id="mixing_intent_grammar">The Grammar for <code class="attribue">intent</code></h4>
 
-   <p>The value of the <code class="attribute">intent</code> attribute, after ignoring white
-   space between tokens, should match the following grammar.</p>
+   <p>The value of the <code class="attribute">intent</code> attribute, should match the following grammar.</p>
 
    <pre class="def bnf">
 intent             := term property* hint? | property+ hint? | application 


### PR DESCRIPTION
This is a draft of chapter 5 with additions covering some of the changes discussed in parallel intent Issues.

Specifically it adds `:` for isa/properties and has wording around white space, empty head self references and error recovery.

It's made a draft PR so it doesn't get merged, but does provide a useful UI to see/comment on the diffs, and also the rendered html respec view which is available  at

https://davidcarlisle.github.io/mathml/#mixing_intent_grammar