### PR TITLE
extend concept matching description

### DIFF
--- a/src/intent.html
+++ b/src/intent.html
@@ -244,10 +244,17 @@ S                  := [ \t\n\r]*
       attribute with entries in an [=Intent Concept Dictionary=], the comparison should be
      <a data-cite="INFRA#ascii-case-insensitive">ASCII case-insensitive</a>
      and also normalize
-     <q>`_`</q> (U+00F5) and <q>`.`</q>  (U+002E) to <q>`-`</q> (U+002D).
-     If the speech hints are not being used
-     and the concept name is being read then each of  `-`, `_` and `.` should be
-     read as an inter-word space.</p>
+     <q>`_`</q> (U+00F5) and <q>`.`</q> (U+002E) to <q>`-`</q>
+     (U+002D).  The use of a concept matches an entry in the
+     dictionary if the concept, arity and fixity property (which may
+     be defaulted as specified in the dictionary) all match.
+     If an entry is found, then as described above, the 
+     AT may use the speech hints to generate suitable text for the
+     <a href="#intent_known_concept">known concept</a>.  
+     If the intent does not match and the dictionary has no entry for the concept
+     with the specified properties and arguments then it is treated as an <a href="#intent_unknown_concept">unknown concept</a>
+     and the concept name should be read as a literal after normalising each of `-`, `_` and `.`
+     to an inter-word space.</p>
   </section>
 
   <section>


### PR DESCRIPTION
As discussed in the call of 2023-10-19, extending the description of matching to a concept dictionary entry to make explicit the fact that arity and fixity need to match which previously was only explicitly spelled out in the core concept dictionary itself.

The core concept list has the text

> An intent term matches a row in the table if the concept name, arity and property all match. Any intent literal that does not match is not an error but is handled by the general rules for unknown concept names (so treated as a literal). Note that unless the intent is explicitly or implicitly (by expanding $argref) used as a function head it will have arity 0.

This PR just adds the same in the existing paragraph describing case insensitive matching and normalising of `-` and `.`