### PR TITLE
[wording] no restrictions from supported concept definition 

### DIFF
--- a/src/intent.html
+++ b/src/intent.html
@@ -316,6 +316,9 @@ S                  := [ \t\n\r]*
    <p>A concept is considered a <dfn id="intent_supported_concept">supported concept</dfn> (by the AT)
      when the normalized name, the fixity property, and the arity
      all match an entry in the AT's concept dictionary.
+     This does not exclude implementations which support additional concepts,
+     as well as concepts with many arities, fixities or aliases,
+     as long as they are mapped appropriately.
      The speech hint in the matching entry
      can be used as a guide for the generation of
      specific audio, replacement text or braille renderings, as appropriate.


### PR DESCRIPTION
Following #515 and the WG meeting on 11/07/2024, we had an offline discussion with @polx on some minimal text that avoids a strict reading of the "supported concept" definition.

This PR contains our proposal.