### PR TITLE
defined boolean attribute type

### DIFF
--- a/src/fundamentals.html
+++ b/src/fundamentals.html
@@ -158,39 +158,39 @@
      <tbody>
 
       <tr>
-       <td id="type_boolean"><dfn><em>boolean</em></dfn></td>
+       <td id="type_boolean"><dfn class="no-export"><em>boolean</em></dfn></td>
        <td>As defined in [[MathML-Core]], a string that is an
               ASCII case-insensitive match to <code>true</code> or
               <code>false</code>.</td>
       </tr>
       <tr>
-       <td id="type_unsigned-integer"><dfn><em>unsigned-integer</em></dfn></td>
+       <td id="type_unsigned-integer"><dfn class="no-export"><em>unsigned-integer</em></dfn></td>
        <td>As defined in [[MathML-Core]], an <a data-cite="CSS-VALUES-3#integer-value"><code>integer</code></a>, whose first character is neither
               U+002D HYPHEN-MINUS character (-) nor
               U+002B PLUS SIGN (+).</td>
       </tr>
 
       <tr>
-       <td id="type_positive-integer"><dfn><em>positive-integer</em></dfn></td>
+       <td id="type_positive-integer"><dfn class="no-export"><em>positive-integer</em></dfn></td>
        <td>An [=unsigned-integer=] not consisting solely of "0"s (U+0030), representing a positive integer</td>
       </tr>
 
       <tr>
-       <td id="type_integer"><dfn><em>integer</em></dfn></td>
+       <td id="type_integer"><dfn class="no-export"><em>integer</em></dfn></td>
        <td>an optional "-"  (U+002D), followed by an [=unsigned-integer=],
        and representing an integer
        </td>
       </tr>
 
       <tr>
-       <td id="type_number"><dfn><em>number</em></dfn></td>
+       <td id="type_number"><dfn class="no-export"><em>number</em></dfn></td>
        <td>
-        an optional prefix of "-" (U+002D), followed by an <a href="#type_unsigned-number">unsigned number</a>,
+        an optional prefix of "-" (U+002D), followed by an [=unsigned-number=],
        representing a terminating decimal number (a type of rational number)</td>
       </tr>
 
       <tr>
-       <td id="type_unsigned-number"><dfn><em>unsigned-number</em></dfn></td>
+       <td id="type_unsigned-number"><dfn class="no-export"><em>unsigned-number</em></dfn></td>
        <td>
          value as defined in
               [[CSS-VALUES-3]] <a data-cite="CSS-VALUES-3#number"><code>number</code></a>, whose first character is neither
@@ -201,17 +201,17 @@
       </tr>
 
       <tr>
-       <td id="type_character"><dfn><em>character</em></dfn></td>
+       <td id="type_character"><dfn class="no-export"><em>character</em></dfn></td>
        <td>a single non-whitespace character</td>
       </tr>
 
       <tr>
-       <td id="type_string"><dfn><em>string</em></dfn></td>
+       <td id="type_string"><dfn class="no-export"><em>string</em></dfn></td>
        <td>an arbitrary, nonempty and finite, string of <em>character</em>s</td>
       </tr>
 
       <tr>
-       <td id="type_length"><dfn><em>length</em></dfn></td>
+       <td id="type_length"><dfn class="no-export"><em>length</em></dfn></td>
        <td>a length, as explained below, <a href="#fund_units"></a></td>
       </tr>
 
@@ -221,24 +221,24 @@
       </tr>
 
       <tr>
-       <td id="type_color"><dfn><em>color</em></dfn></td>
+       <td id="type_color"><dfn class="no-export"><em>color</em></dfn></td>
        <td>a color, using the syntax specified by [[CSS-Color-3]]</td>
       </tr>
 
       <tr>
-       <td id="type_id"><dfn><em>id</em></dfn></td>
+       <td id="type_id"><dfn class="no-export"><em>id</em></dfn></td>
        <td>an identifier, unique within the document;
        must satisfy the NAME syntax of the XML recommendation [[XML]]</td>
       </tr>
 
       <tr>
-       <td id="type_idref"><dfn><em>idref</em></dfn></td>
+       <td id="type_idref"><dfn class="no-export"><em>idref</em></dfn></td>
        <td>an identifier referring to another element within the document;
        must satisfy the NAME syntax of the XML recommendation [[XML]]</td>
       </tr>
 
       <tr>
-       <td id="type_uri"><dfn><em>URI</em></dfn></td>
+       <td id="type_uri"><dfn class="no-export"><em>URI</em></dfn></td>
        <td>a Uniform Resource Identifier [[RFC3986]]. Note that the attribute value
        is typed in the schema as anyURI which allows any sequence of XML characters.
        Systems needing to use this string as a URI must encode the bytes of the UTF-8 encoding

--- a/src/fundamentals.html
+++ b/src/fundamentals.html
@@ -155,9 +155,14 @@
       </tr>
      </thead>
 
-     <tbody
->
+     <tbody>
 
+      <tr>
+       <td id="type_boolean"><dfn><em>boolean</em></dfn></td>
+       <td>As defined in [[MathML-Core]], a string that is an
+              ASCII case-insensitive match to <code>true</code> or
+              <code>false</code>.</td>
+      </tr>
       <tr>
        <td id="type_unsigned-integer"><dfn><em>unsigned-integer</em></dfn></td>
        <td>As defined in [[MathML-Core]], an <a data-cite="CSS-VALUES-3#integer-value"><code>integer</code></a>, whose first character is neither
@@ -178,6 +183,13 @@
       </tr>
 
       <tr>
+       <td id="type_number"><dfn><em>number</em></dfn></td>
+       <td>
+        an optional prefix of "-" (U+002D), followed by an <a href="#type_unsigned-number">unsigned number</a>,
+       representing a terminating decimal number (a type of rational number)</td>
+      </tr>
+
+      <tr>
        <td id="type_unsigned-number"><dfn><em>unsigned-number</em></dfn></td>
        <td>
          value as defined in
@@ -186,13 +198,6 @@
               U+002B PLUS SIGN (+),
               representing a non-negative terminating decimal number
        (a type of rational number)</td>
-      </tr>
-
-      <tr>
-       <td id="type_number"><dfn><em>number</em></dfn></td>
-       <td>
-        an optional prefix of "-" (U+002D), followed by an <a href="#type_unsigned-number">unsigned number</a>,
-       representing a terminating decimal number (a type of rational number)</td>
       </tr>
 
       <tr>

--- a/src/presentation-markup.html
+++ b/src/presentation-markup.html
@@ -1969,7 +1969,7 @@
  
        <tr>
         <td rowspan="2" class="attname"><a class="coreyes" href="https://w3c.github.io/mathml-core/spec.html#dfn-stretchy">stretchy</a></td>
-        <td>"true" | "false"</td>
+        <td><a class="intref" href="#type_boolean"><em>boolean</em></a></td>
         <td><em>set by dictionary</em> (false)</td>
        </tr>
  
@@ -1982,7 +1982,7 @@
  
        <tr>
         <td rowspan="2" class="attname"><a class="coreyes" href="https://w3c.github.io/mathml-core/spec.html#dfn-symmetric">symmetric</a></td>
-        <td>"true" | "false"</td>
+        <td><a class="intref" href="#type_boolean"><em>boolean</em></a></td>
         <td><em>set by dictionary</em> (false)</td>
        </tr>
  
@@ -2029,7 +2029,7 @@
  
        <tr>
         <td rowspan="2" class="attname"><a class="coreyes" href="https://w3c.github.io/mathml-core/spec.html#dfn-largeop">largeop</a></td>
-        <td>"true" | "false"</td>
+        <td><a class="intref" href="#type_boolean"><em>boolean</em></a></td>
         <td><em>set by dictionary</em> (false)</td>
        </tr>
  
@@ -2047,7 +2047,7 @@
  
        <tr>
         <td rowspan="2" class="attname"><a class="coreyes" href="https://w3c.github.io/mathml-core/spec.html#dfn-movablelimits">movablelimits</a></td>
-        <td>"true" | "false"</td>
+        <td><a class="intref" href="#type_boolean"><em>boolean</em></a></td>
         <td><em>set by dictionary</em> (false)</td>
        </tr>
  
@@ -2066,7 +2066,7 @@
  
        <tr>
         <td rowspan="2" class="attname"><span class="coreno">accent</span></td>
-        <td>"true" | "false"</td>
+        <td><a class="intref" href="#type_boolean"><em>boolean</em></a></td>
         <td><em>set by dictionary</em> (false)</td>
        </tr>
  
@@ -3753,7 +3753,7 @@
  
  <tr>
  <td rowspan="2" class="attname"><span class="coreno">bevelled</span></td>
- <td>"true" | "false"</td>
+ <td><a class="intref" href="#type_boolean"><em>boolean</em></a></td>
  <td>false</td>
  </tr>
  
@@ -4123,7 +4123,7 @@
  
  <tr>
   <td rowspan="2" class="attname"><a class="coreyes" href="https://w3c.github.io/mathml-core/spec.html#dfn-displaystyle">displaystyle</a></td>
- <td>"true" | "false"</td>
+ <td><a class="intref" href="#type_boolean"><em>boolean</em></a></td>
  <td><em>inherited</em></td>
  </tr>
  
@@ -5728,7 +5728,7 @@
  
       <tr>
        <td rowspan="2" class="attname"><a class="coreyes" href="https://w3c.github.io/mathml-core/spec.html#dfn-accentunder">accentunder</a></td>
-       <td>"true" | "false"</td>
+       <td><a class="intref" href="#type_boolean"><em>boolean</em></a></td>
        <td><em>automatic</em></td>
       </tr>
  
@@ -5856,7 +5856,7 @@
  
        <tr>
         <td rowspan="2" class="attname"><a class="coreyes" href="https://w3c.github.io/mathml-core/spec.html#dfn-accent">accent</a></td>
-        <td>"true" | "false"</td>
+        <td><a class="intref" href="#type_boolean"><em>boolean</em></a></td>
         <td><em>automatic</em></td>
        </tr>
  
@@ -6005,7 +6005,7 @@
  
       <tr>
        <td rowspan="2" class="attname"><a class="coreyes" href="https://w3c.github.io/mathml-core/spec.html#dfn-accent">accent</a></td>
-       <td>"true" | "false"</td>
+       <td><a class="intref" href="#type_boolean"><em>boolean</em></a></td>
        <td><em>automatic</em></td>
       </tr>
  
@@ -6019,7 +6019,7 @@
  
       <tr>
        <td rowspan="2" class="attname"><a class="coreyes" href="https://w3c.github.io/mathml-core/spec.html#dfn-accentunder">accentunder</a></td>
-       <td>"true" | "false"</td>
+       <td><a class="intref" href="#type_boolean"><em>boolean</em></a></td>
        <td><em>automatic</em></td>
       </tr>
  
@@ -6395,7 +6395,7 @@
  
       <tr>
        <td rowspan="2" class="attname"><span class="coreno">alignmentscope</span></td>
-       <td>("true" | "false") +</td>
+       <td>(<a class="intref" href="#type_boolean"><em>boolean</em></a>) +</td>
        <td>true</td>
       </tr>
  
@@ -6550,7 +6550,7 @@
  
       <tr>
        <td rowspan="2" class="attname"><span class="coreno">equalrows</span></td>
-       <td>"true" | "false"</td>
+       <td><a class="intref" href="#type_boolean"><em>boolean</em></a></td>
        <td>false</td>
       </tr>
  
@@ -6562,7 +6562,7 @@
  
       <tr>
        <td rowspan="2" class="attname"><span class="coreno">equalcolumns</span></td>
-       <td>"true" | "false"</td>
+       <td><a class="intref" href="#type_boolean"><em>boolean</em></a></td>
        <td>false</td>
       </tr>
  
@@ -6574,7 +6574,7 @@
  
       <tr>
        <td rowspan="2" class="attname"><span class="coreno">displaystyle</span></td>
-       <td>"true" | "false"</td>
+       <td><a class="intref" href="#type_boolean"><em>boolean</em></a></td>
        <td>false</td>
       </tr>
  

--- a/src/presentation-markup.html
+++ b/src/presentation-markup.html
@@ -1969,7 +1969,7 @@
  
        <tr>
         <td rowspan="2" class="attname"><a class="coreyes" href="https://w3c.github.io/mathml-core/spec.html#dfn-stretchy">stretchy</a></td>
-        <td><a class="intref" href="#type_boolean"><em>boolean</em></a></td>
+        <td><em>[=boolean=]</em></td>
         <td><em>set by dictionary</em> (false)</td>
        </tr>
  
@@ -1982,7 +1982,7 @@
  
        <tr>
         <td rowspan="2" class="attname"><a class="coreyes" href="https://w3c.github.io/mathml-core/spec.html#dfn-symmetric">symmetric</a></td>
-        <td><a class="intref" href="#type_boolean"><em>boolean</em></a></td>
+        <td><em>[=boolean=]</em></td>
         <td><em>set by dictionary</em> (false)</td>
        </tr>
  
@@ -2029,7 +2029,7 @@
  
        <tr>
         <td rowspan="2" class="attname"><a class="coreyes" href="https://w3c.github.io/mathml-core/spec.html#dfn-largeop">largeop</a></td>
-        <td><a class="intref" href="#type_boolean"><em>boolean</em></a></td>
+        <td><em>[=boolean=]</em></td>
         <td><em>set by dictionary</em> (false)</td>
        </tr>
  
@@ -2047,7 +2047,7 @@
  
        <tr>
         <td rowspan="2" class="attname"><a class="coreyes" href="https://w3c.github.io/mathml-core/spec.html#dfn-movablelimits">movablelimits</a></td>
-        <td><a class="intref" href="#type_boolean"><em>boolean</em></a></td>
+        <td><em>[=boolean=]</em></td>
         <td><em>set by dictionary</em> (false)</td>
        </tr>
  
@@ -2066,7 +2066,7 @@
  
        <tr>
         <td rowspan="2" class="attname"><span class="coreno">accent</span></td>
-        <td><a class="intref" href="#type_boolean"><em>boolean</em></a></td>
+        <td><em>[=boolean=]</em></td>
         <td><em>set by dictionary</em> (false)</td>
        </tr>
  
@@ -3753,7 +3753,7 @@
  
  <tr>
  <td rowspan="2" class="attname"><span class="coreno">bevelled</span></td>
- <td><a class="intref" href="#type_boolean"><em>boolean</em></a></td>
+ <td><em>[=boolean=]</em></td>
  <td>false</td>
  </tr>
  
@@ -4123,7 +4123,7 @@
  
  <tr>
   <td rowspan="2" class="attname"><a class="coreyes" href="https://w3c.github.io/mathml-core/spec.html#dfn-displaystyle">displaystyle</a></td>
- <td><a class="intref" href="#type_boolean"><em>boolean</em></a></td>
+ <td><em>[=boolean=]</em></td>
  <td><em>inherited</em></td>
  </tr>
  
@@ -5728,7 +5728,7 @@
  
       <tr>
        <td rowspan="2" class="attname"><a class="coreyes" href="https://w3c.github.io/mathml-core/spec.html#dfn-accentunder">accentunder</a></td>
-       <td><a class="intref" href="#type_boolean"><em>boolean</em></a></td>
+       <td><em>[=boolean=]</em></td>
        <td><em>automatic</em></td>
       </tr>
  
@@ -5856,7 +5856,7 @@
  
        <tr>
         <td rowspan="2" class="attname"><a class="coreyes" href="https://w3c.github.io/mathml-core/spec.html#dfn-accent">accent</a></td>
-        <td><a class="intref" href="#type_boolean"><em>boolean</em></a></td>
+        <td><em>[=boolean=]</em></td>
         <td><em>automatic</em></td>
        </tr>
  
@@ -6005,7 +6005,7 @@
  
       <tr>
        <td rowspan="2" class="attname"><a class="coreyes" href="https://w3c.github.io/mathml-core/spec.html#dfn-accent">accent</a></td>
-       <td><a class="intref" href="#type_boolean"><em>boolean</em></a></td>
+       <td><em>[=boolean=]</em></td>
        <td><em>automatic</em></td>
       </tr>
  
@@ -6019,7 +6019,7 @@
  
       <tr>
        <td rowspan="2" class="attname"><a class="coreyes" href="https://w3c.github.io/mathml-core/spec.html#dfn-accentunder">accentunder</a></td>
-       <td><a class="intref" href="#type_boolean"><em>boolean</em></a></td>
+       <td><em>[=boolean=]</em></td>
        <td><em>automatic</em></td>
       </tr>
  
@@ -6395,7 +6395,7 @@
  
       <tr>
        <td rowspan="2" class="attname"><span class="coreno">alignmentscope</span></td>
-       <td>(<a class="intref" href="#type_boolean"><em>boolean</em></a>) +</td>
+       <td>(<em>[=boolean=]</em>) +</td>
        <td>true</td>
       </tr>
  
@@ -6550,7 +6550,7 @@
  
       <tr>
        <td rowspan="2" class="attname"><span class="coreno">equalrows</span></td>
-       <td><a class="intref" href="#type_boolean"><em>boolean</em></a></td>
+       <td><em>[=boolean=]</em></td>
        <td>false</td>
       </tr>
  
@@ -6562,7 +6562,7 @@
  
       <tr>
        <td rowspan="2" class="attname"><span class="coreno">equalcolumns</span></td>
-       <td><a class="intref" href="#type_boolean"><em>boolean</em></a></td>
+       <td><em>[=boolean=]</em></td>
        <td>false</td>
       </tr>
  
@@ -6574,7 +6574,7 @@
  
       <tr>
        <td rowspan="2" class="attname"><span class="coreno">displaystyle</span></td>
-       <td><a class="intref" href="#type_boolean"><em>boolean</em></a></td>
+       <td><em>[=boolean=]</em></td>
        <td>false</td>
       </tr>
  


### PR DESCRIPTION
Add a boolean attrbute type (refencing the existing definition in MathML-Core), replace all `"true" | "false"` by a reference to boolean.

This addresses a main case highlighted by #178