### PR TITLE
remove open properties list (WG call 2025-03-13)

### DIFF
--- a/src/accessibility.html
+++ b/src/accessibility.html
@@ -441,7 +441,7 @@ could be marked up as an operator by means of
   with each non-trivial component described.
 </p>
 
-<div class="example mathml mmlcore">
+<div class="example mathml">
 <pre>
 &lt;mrow aria-description="circumference of a circle"&gt;
   &lt;mn&gt;2&lt;/mn&gt;

--- a/src/accessibility.html
+++ b/src/accessibility.html
@@ -441,7 +441,7 @@ could be marked up as an operator by means of
   with each non-trivial component described.
 </p>
 
-<div class="example mathml">
+<div class="example mathml-fragment">
 <pre>
 &lt;mrow aria-description="circumference of a circle"&gt;
   &lt;mn&gt;2&lt;/mn&gt;

--- a/src/intent.html
+++ b/src/intent.html
@@ -221,20 +221,14 @@ S                  := [ \t\n\r]*
    but as with any properties, is by default ignored but may have a
    system-specific effect.</p>
 
-    <p>As with [=Concepts=], The Working group maintains two lists
-      of [=property=] values.</p>
+    <p>Similar to the lists of [=Concepts=], The Working Group maintains a list of [=property=] values that should be implemented.</p>
     <ul>
-      <li><dfn id="intent-core-properties">Core properties</dfn>: This is a
-      <a href="https://w3c.github.io/mathml-docs/intent-core-properties">list core of properties</a>
+      <li><dfn id="intent-core-properties">Properties list</dfn>: This is the full
+      <a href="https://w3c.github.io/mathml-docs/intent-core-properties">list of properties</a>
       maintained by the Math Working Group</li>
-       <li><dfn id="intent-open-properties">Open properties</dfn>: This is an
-      <a href="https://w3c.github.io/mathml-docs/intent-open-properties">open list of properties</a>
-      with contributions welcome from the community.
-      Implementors of MathML systems that implement additional properties are encouraged
-      to make a pull request to add them to the list of  [=Open Properties=].</li>
     </ul>
-   <p>The definitive list of [=Core Properties=] is maintained at
-   Github. Here, we describe the major classes of property affecting speech generation
+   <p>The definitive  [=Properties list=] is maintained at
+   GitHub. Here, we describe the major classes of property affecting speech generation
    below.</p>
    <dl>
     <dt id="intent_fixity_hint"><code>:prefix</code>,

--- a/src/intent.html
+++ b/src/intent.html
@@ -221,15 +221,13 @@ S                  := [ \t\n\r]*
    but as with any properties, is by default ignored but may have a
    system-specific effect.</p>
 
-    <p>Similar to the lists of [=Concepts=], The Working Group maintains a list of [=property=] values that should be implemented.</p>
+    <p>Similar to the lists of [=Concepts=], the Working Group maintains a [=Properties list=] of [=property=] values that should be implemented.</p>
     <ul>
-      <li><dfn id="intent-core-properties">Properties list</dfn>: This is the full
+      <li><dfn id="intent-core-properties">Properties list</dfn>: The definitive
       <a href="https://w3c.github.io/mathml-docs/intent-core-properties">list of properties</a>
-      maintained by the Math Working Group</li>
+      maintained by the Math Working Group.</li>
     </ul>
-   <p>The definitive  [=Properties list=] is maintained at
-   GitHub. Here, we describe the major classes of property affecting speech generation
-   below.</p>
+    <p>Here, we describe the major classes of property affecting speech generation.</p>
    <dl>
     <dt id="intent_fixity_hint"><code>:prefix</code>,
     <code>:infix</code>, <code>:postfix</code>,
@@ -274,23 +272,24 @@ S                  := [ \t\n\r]*
       and just speak the elements with a literal interpretation, including leaf content (eg <q>|</q> might be spoken as <q>vertical bar</q>).</p>
     </dd>
     <dt id="intent_table_properties"><code>:matrix</code>,
-    <code>:system-of-equations</code>, <code>:lines</code>, <code>:continued-equation</code></dt>
+    <code>:system-of-equations</code>, <code>:lines</code>, <code>:continued-row</code>, <code>:equation-label</code></dt>
     <dd>
      <p>These properties may be used on an <code>mtable</code> or on a
-    [=reference=] to an <code>mtable</code>. They affect the way the
-     parts of an alignment are announced.</p>
+       [=reference=] to an <code>mtable</code>, `<code>mtr</mtr> and <code>mtd</code>.
+     They affect the way the parts of an alignment are announced.</p>
      <p>The exact wordings used are system specfic</p>
      <ul>
       <li><code>:matrix</code>
-     should be read in style suitable for matricies, with typically
+     should be read in style suitable for matrices, with typically
       column numbers being announced.</li>
       <li><code>:system-of-equations</code> should be read in style suitable for
       displayed equations (and inequalities), with typically
       column numbers not being announced. Each table row would
       normally be announced as an "equation" but a
-      `continued-equation` property on an <code>mtr</code> indicates
+      `continued-row` property on an <code>mtr</code> indicates
       that the row continues an equation wrapped from the row
-      above.</li>
+	above.</li>
+      <li><code>:equation-label</code> may be used on an <code>mtd</code> to mark a cell containing an equation label.</li>
      </ul>
     </dd>
    </dl>
@@ -701,7 +700,7 @@ equation 2; y, is greater than, x minus 3;
       &lt;mi>d&lt;/mi>
     &lt;/mtd>
   &lt;/mtr>
-  &lt;mtr intent=':continued-equation'>
+  &lt;mtr intent=':continued-row'>
     &lt;mtd columnalign="right">&lt;/mtd>
     &lt;mtd columnalign="center">&lt;/mtd>
     &lt;mtd columnalign="left">


### PR DESCRIPTION
As agreed on the WG call of 2025-03-13, the consensus is to drop the open properties list.

This PR adjusts the wording in the spec to just refer to a single properties list.

It is dependent on two PR in mathml-docs

add `:equation-label`

https://github.com/w3c/mathml-docs/pull/84


move `:pause-xxx` to the main list.

https://github.com/w3c/mathml-docs/pull/86