### PR TITLE
delete bold plus example for #385

### DIFF
--- a/src/presentation-markup.html
+++ b/src/presentation-markup.html
@@ -2401,43 +2401,39 @@
     <h5 id="presm_ex_operators">Examples with ordinary operators</h5>
  
     <div class="example mathml mmlcore">
-     <pre>&lt;mo&gt; + &lt;/mo&gt;                    </pre>
+     <pre>&lt;mo&gt;+&lt;/mo&gt;                    </pre>
     </div>
  
     <div class="example mathml mmlcore">
-     <pre>&lt;mo&gt; &amp;lt; &lt;/mo&gt;                 </pre>
+     <pre>&lt;mo&gt;&amp;lt;&lt;/mo&gt;                 </pre>
     </div>
  
     <div class="example mathml mmlcore">
-     <pre>&lt;mo&gt; &#x2264; &lt;/mo&gt; </pre>
+     <pre>&lt;mo&gt;&#x2264;&lt;/mo&gt; </pre>
     </div>
  
     <div class="example mathml mmlcore">
-     <pre>&lt;mo&gt; &amp;lt;= &lt;/mo&gt;                </pre>
+     <pre>&lt;mo&gt;&amp;lt;=&lt;/mo&gt;                </pre>
     </div>
  
     <div class="example mathml mmlcore">
-     <pre>&lt;mo&gt; ++ &lt;/mo&gt;                   </pre>
+     <pre>&lt;mo&gt;++&lt;/mo&gt;                   </pre>
     </div>
  
     <div class="example mathml mmlcore">
-     <pre>&lt;mo&gt; &#x2211; &lt;/mo&gt; </pre>
+     <pre>&lt;mo&gt;&#x2211;&lt;/mo&gt; </pre>
     </div>
  
     <div class="example mathml mmlcore">
-     <pre>&lt;mo&gt; .NOT. &lt;/mo&gt;                </pre>
+     <pre>&lt;mo&gt;.NOT.&lt;/mo&gt;                </pre>
     </div>
  
     <div class="example mathml mmlcore">
-     <pre>&lt;mo&gt; and &lt;/mo&gt;                  </pre>
+     <pre>&lt;mo&gt;and&lt;/mo&gt;                  </pre>
     </div>
  
     <div class="example mathml mmlcore">
-     <pre>&lt;mo&gt; &amp;#x2062;&lt;!--InvisibleTimes--&gt; &lt;/mo&gt; </pre>
-    </div>
- 
-    <div class="example mathml mmlcore">
-     <pre>&lt;mo mathvariant='bold'&gt; + &lt;/mo&gt; </pre>
+     <pre>&lt;mo&gt;&amp;#x2062;&lt;!--InvisibleTimes--&gt;&lt;/mo&gt; </pre>
     </div>
  
    </section>


### PR DESCRIPTION
as described in #385 using `mathvariant='bold'` with `+` is incorrect, this simply deletes the example. It also removes the  white space at start and end of the `<mo>` in the remaining examples to be consistent with the current definition in MathML-Core which does not strip this space.