### PR TITLE
remove decimalpoint from mstyle

### DIFF
--- a/src/presentation-markup.html
+++ b/src/presentation-markup.html
@@ -4152,28 +4152,7 @@
    see <a href="#presm_lbattrs"></a>
   </td>
  </tr>
- 
- <tr>
- <td rowspan="2" class="attname"><span class="coreno">decimalpoint</span></td>
- <td><em>[=character=]</em></td>
- <td>.</td>
- </tr>
- 
- <tr>
-  <td colspan="2" class="attdesc">
-   Specifies the character used to determine the alignment point within
-   <a class="intref" href="#presm_mstack"><code class="element">mstack</code></a>
-   and
-   <a class="intref" href="#presm_mtable"><code class="element">mtable</code></a> columns
-   when the "decimalpoint" value is used to specify the alignment.
-   The default, ".", is the decimal separator used to separate the integral
-   and decimal fractional parts of floating point numbers in many countries.
-   (See <a href="#presm_elementary"></a> and <a href="#presm_malign"></a>).
- </td>
- </tr>
- </tbody>
- </table>
- 
+  
  <p>If <code class="attribute">scriptlevel</code> is changed incrementally by an
  <code class="element">mstyle</code> element that also sets certain other
  attributes, the overall effect of the changes may depend on the order


### PR DESCRIPTION
Small fix for #1 -- remove `decimalpoint` from `mstyle`. This still need to be made a global attr to align with core.

Note: it also needs to be removed from RelaxNG.