### PR TITLE
Space like

### DIFF
--- a/src/presentation-markup.html
+++ b/src/presentation-markup.html
@@ -4152,28 +4152,7 @@
    see <a href="#presm_lbattrs"></a>
   </td>
  </tr>
- 
- <tr>
- <td rowspan="2" class="attname"><span class="coreno">decimalpoint</span></td>
- <td><em>[=character=]</em></td>
- <td>.</td>
- </tr>
- 
- <tr>
-  <td colspan="2" class="attdesc">
-   Specifies the character used to determine the alignment point within
-   <a class="intref" href="#presm_mstack"><code class="element">mstack</code></a>
-   and
-   <a class="intref" href="#presm_mtable"><code class="element">mtable</code></a> columns
-   when the "decimalpoint" value is used to specify the alignment.
-   The default, ".", is the decimal separator used to separate the integral
-   and decimal fractional parts of floating point numbers in many countries.
-   (See <a href="#presm_elementary"></a> and <a href="#presm_malign"></a>).
- </td>
- </tr>
- </tbody>
- </table>
- 
+  
  <p>If <code class="attribute">scriptlevel</code> is changed incrementally by an
  <code class="element">mstyle</code> element that also sets certain other
  attributes, the overall effect of the changes may depend on the order

--- a/src/presentation-markup.html
+++ b/src/presentation-markup.html
@@ -3272,8 +3272,8 @@
  <ul>
  
   <li>
-   <p>an <code class="element">mtext</code> element all of whose characters are
-    Unicode spacing characters except U+0020 (space);</p> </li>
+   <p>an <code class="element">mtext</code> element that is empty or that has only text content which contains solely
+    Unicode spacing characters;</p> </li>
  
   <li>
    <p>an <code class="element">mspace</code>,

--- a/src/presentation-markup.html
+++ b/src/presentation-markup.html
@@ -3272,7 +3272,11 @@
  <ul>
  
   <li>
-   <p>an <code class="element">mtext</code>, <code class="element">mspace</code>,
+   <p>an <code class="element">mtext</code> element all of whose characters are
+    Unicode spacing characters except U+0020 (space);</p> </li>
+ 
+  <li>
+   <p>an <code class="element">mspace</code>,
  <code class="element">maligngroup</code>, or <code class="element">malignmark</code>
  element;</p> </li>
  


### PR DESCRIPTION
Make `mtext` be more restrictive as to when it is space-like as per the 28 Oct, 2025 meeting.

Fixes #548 