### PR TITLE
Make attributes with enumerated string values be ASCII case-insensitive 

### DIFF
--- a/src/fundamentals.html
+++ b/src/fundamentals.html
@@ -339,6 +339,9 @@
     a single whitespace character for separating parts of a value.
     Moreover, leading and trailing whitespace in attribute values should be avoided.</p>
 
+    <p>For compatibility with HTML, attributes defined with an enumerated list of string values
+    are to be compared as <a data-cite="INFRA#ascii-case-insensitive">ASCII case-insensitive</a>.</p>
+
     <p>For most numerical attributes, only those in a subset of the
     expressible values are sensible; values outside this subset are not
     errors, unless otherwise specified, but rather are rounded up or down
@@ -368,7 +371,7 @@
      <a id="type_unit" data-cite="CSS-VALUES-3#typedef-length-percentage"><code>&lt;length-percentage&gt;</code></a>
      syntax defined in [[CSS-VALUES-3]].
      MathML Full extends length syntax by accepting also a <dfn>namedspace</dfn>
-     being one of:</p>
+     being an <a data-cite="INFRA#ascii-case-insensitive">ASCII case-insensitive</a> match to one of:</p>
       <table class="data">
        <thead>
 	<tr><th>Positive space</th><th>Negative space</th><th>Value</th></tr>
@@ -811,6 +814,8 @@
        and any immediately following punctuation.
        When the display attribute is missing, a rendering agent is free to initialize
        as appropriate to the context.
+       <br/>Comparisons are <a data-cite="INFRA#ascii-case-insensitive">ASCII case-insensitive</a>,
+       where all matching strings are allowed as values.
       </td>
      </tr>
 
@@ -839,6 +844,8 @@
       <td colspan="2" class="attdesc">
        specifies the preferred handing in cases where an expression is too long to
        fit in the allowed width. See the discussion below.
+       <br/>Comparisons are <a data-cite="INFRA#ascii-case-insensitive">ASCII case-insensitive</a>,
+       where all matching strings are allowed as values.
       </td>
      </tr>
 
@@ -901,6 +908,8 @@
        (not necessarily the baseline). This attribute only has effect
        when <code class="attribute">display</code>=<code class="attributevalue">inline</code>.
        By default, the bottom of the image aligns to the baseline.
+       <br>Comparisons are <a data-cite="INFRA#ascii-case-insensitive">ASCII case-insensitive</a>,
+       where all matching strings are allowed as values.
       </td>
      </tr>
 

--- a/src/presentation-markup.html
+++ b/src/presentation-markup.html
@@ -464,6 +464,9 @@
      attribute on <code class="element">mrow</code> or <code class="element">mstyle</code> elements.
      When not specified, all elements inherit the directionality of their container.
     </p>
+
+    <br/>Comparisons of <code class="attribute">dir</code> are <a data-cite="INFRA#ascii-case-insensitive">ASCII case-insensitive</a>,
+       where all matching strings are allowed as values.
    </section>
  
    <section>
@@ -1095,6 +1098,8 @@
         <td colspan="2" class="attdesc">
           Changes the <code>displaystyle</code> in effect for the children.
           See <a href="#presm_scriptlevel"></a>.
+          <br/>Comparisons are <a data-cite="INFRA#ascii-case-insensitive">ASCII case-insensitive</a>,
+          where all matching strings are allowed as values.
         </td>
       </tr>      
 </tbody>
@@ -1155,7 +1160,9 @@
       <tr>
         <td colspan="2" class="attdesc">
         Specifies the default linebreakstyle to use for infix operators;
-        see <a href="#presm_lbattrs"></a>
+        see <a href="#presm_lbattrs"></a>.
+        <br/>Comparisons are <a data-cite="INFRA#ascii-case-insensitive">ASCII case-insensitive</a>,
+       where all matching strings are allowed as values.
         </td>
       </tr>
       
@@ -1488,6 +1495,8 @@
       <td colspan="2" class="attdesc">
        Specifies the logical class of the token. Note that this class
        is more than styling, it typically conveys semantic intent; see the discussion below.
+       <br/>Comparisons are <a data-cite="INFRA#ascii-case-insensitive">ASCII case-insensitive</a>,
+       where all matching strings are allowed as values.
       </td>
      </tr>
  
@@ -1504,6 +1513,8 @@
        smaller or larger than the current font size, but leave the exact proportions
        unspecified; <code class="attributevalue">normal</code> is allowed for completeness, but since
        it is equivalent to <code class="attributevalue">100%</code> or <code class="attributevalue">1em</code>, it has no effect.
+       <br/>Comparisons are <a data-cite="INFRA#ascii-case-insensitive">ASCII case-insensitive</a>,
+       where all matching strings are allowed as values.
       </td>
      </tr>
  
@@ -1520,6 +1531,8 @@
        This attribute should only be needed in rare cases involving weak or neutral characters;
        see <a href="#presm_bidi_math"></a> for further discussion.
        <span>It has no effect on <code class="element">mspace</code>.</span>
+       <br/>Comparisons are <a data-cite="INFRA#ascii-case-insensitive">ASCII case-insensitive</a>,
+       where all matching strings are allowed as values.
       </td>
      </tr>
     </tbody>
@@ -1733,6 +1746,8 @@
         Specifies the logical class of the token.
         The default is <code class="attributevalue">normal</code> (non-slanted) unless the content
         is a single character, in which case it would be <code class="attributevalue">italic</code>.
+        <br/>Comparisons are <a data-cite="INFRA#ascii-case-insensitive">ASCII case-insensitive</a>,
+       where all matching strings are allowed as values.
        </td>
       </tr>
  
@@ -2068,6 +2083,8 @@
    dictionary
    which affects the spacing and other default properties;
    see <a href="#presm_formdefval"></a>.
+   <br/>Comparisons are <a data-cite="INFRA#ascii-case-insensitive">ASCII case-insensitive</a>,
+       where all matching strings are allowed as values.
         </td>
        </tr>
  
@@ -2253,6 +2270,8 @@
    for automatic linebreaking, <code class="attributevalue">nobreak</code> forbids a break;
    <code class="attributevalue">goodbreak</code> suggests a good position;
    <code class="attributevalue">badbreak</code> suggests a poor position.
+   <br/>Comparisons are <a data-cite="INFRA#ascii-case-insensitive">ASCII case-insensitive</a>,
+       where all matching strings are allowed as values.
         </td>
        </tr>
  
@@ -2290,6 +2309,8 @@
    <code class="attributevalue">after</code> or <code class="attributevalue">duplicate</code>) can be specified by
    the application or bound by <a class="intref" href="#presm_mstyle"><code class="element">mstyle</code></a>
    (<code class="attributevalue">before</code> corresponds to the most common style of linebreaking).
+   <br/>Comparisons are <a data-cite="INFRA#ascii-case-insensitive">ASCII case-insensitive</a>,
+       where all matching strings are allowed as values.
         </td>
        </tr>
  
@@ -2366,6 +2387,8 @@
         <td colspan="2" class="attdesc">
    Specifies the positioning of lines when linebreaking takes place within an <code class="element">mrow</code>;
    see below for discussion of the attribute values.
+   <br/>Comparisons are <a data-cite="INFRA#ascii-case-insensitive">ASCII case-insensitive</a>,
+       where all matching strings are allowed as values.
         </td>
        </tr>
  
@@ -2421,6 +2444,8 @@
    Specifies the indentation style to use for the first line of a formula;
    the value <code class="attributevalue">indentalign</code> (the default) means
    to indent the same way as used for the general line.
+   <br/>Comparisons are <a data-cite="INFRA#ascii-case-insensitive">ASCII case-insensitive</a>,
+       where all matching strings are allowed as values.
         </td>
        </tr>
  
@@ -2434,7 +2459,7 @@
         <td colspan="2" class="attdesc">
    Specifies the offset to use for the first line of a formula;
    the value <code class="attributevalue">indentshift</code> (the default) means
-   to use the same offset as used for the general line.
+   to use the same offset as used for the general line. It is <a data-cite="INFRA#ascii-case-insensitive">ASCII case-insensitive</a>.
    <span>Percentage values and numbers without unit are interpreted as described for <code class="attribute">indentshift</code>.</span>
         </td>
        </tr>
@@ -2453,6 +2478,8 @@
    to indent the same way as used for the general line.
    When there are exactly two lines, the value of this attribute should
    be used for the second line in preference to <code class="attribute">indentalign</code>.
+   <br/>Comparisons are <a data-cite="INFRA#ascii-case-insensitive">ASCII case-insensitive</a>,
+       where all matching strings are allowed as values.
         </td>
        </tr>
  
@@ -2467,7 +2494,7 @@
    Specifies the offset to use for the last line when a linebreak
    occurs within a given <code class="element">mrow</code>;
    the value <code class="attributevalue">indentshift</code> (the default) means
-   to indent the same way as used for the general line.
+   to indent the same way as used for the general line. It is <a data-cite="INFRA#ascii-case-insensitive">ASCII case-insensitive</a>.
    When there are exactly two lines, the value of this attribute should
    be used for the second line in preference to <code class="attribute">indentshift</code>.
    <span>Percentage values and numbers without unit are interpreted as described for <code class="attribute">indentshift</code>.</span>
@@ -3658,6 +3685,8 @@
    specifies the overall directionality <code>ltr</code> (Left To Right) or
    <code>rtl</code> (Right To Left) to use to layout the children of the row.
    See <a href="#presm_bidi_math"></a> for further discussion.
+   <br/>Comparisons are <a data-cite="INFRA#ascii-case-insensitive">ASCII case-insensitive</a>,
+       where all matching strings are allowed as values.
  </td>
  </tr>
  </tbody>
@@ -3854,6 +3883,8 @@
  However, if OpenType Math fonts are available then the renderer should set <code class="attributevalue">medium</code> to
  the value <code class="attribute">MATH.MathConstants.fractionRuleThickness</code>
  (the default in <a href="https://www.w3.org/TR/mathml-core/#fractions-mfrac">MathML-Core</a>).
+ <br/>Comparisons are <a data-cite="INFRA#ascii-case-insensitive">ASCII case-insensitive</a>,
+       where all matching strings are allowed as values.
  <br/>
  Note: MathML Core only allows <a data-cite="CSS-VALUES-3#typedef-length-percentage"><code>&lt;length-percentage&gt;</code></a> values.
  </td>
@@ -3868,6 +3899,8 @@
  <tr>
   <td colspan="2" class="attdesc">
    Specifies the alignment of the numerator over the fraction.
+   <br/>Comparisons are <a data-cite="INFRA#ascii-case-insensitive">ASCII case-insensitive</a>,
+       where all matching strings are allowed as values.
  </td>
  </tr>
  
@@ -3880,6 +3913,8 @@
  <tr>
   <td colspan="2" class="attdesc">
    Specifies the alignment of the denominator under the fraction.
+   <br/>Comparisons are <a data-cite="INFRA#ascii-case-insensitive">ASCII case-insensitive</a>,
+       where all matching strings are allowed as values.
  </td>
  </tr>
  
@@ -5196,6 +5231,8 @@
        The default has been changed so that if no <code class="attname">notation</code> is given,
        or if it is an empty string,
        then <code class="element">menclose</code> should not draw.
+       <br/>Comparisons are <a data-cite="INFRA#ascii-case-insensitive">ASCII case-insensitive</a>,
+       where all matching strings are allowed as values.
       </td>
      </tr>
     </tbody>
@@ -5748,6 +5785,8 @@
         the core of underscripts that are embellished operators should stretch to cover the
         base,
         but the alignment is based on the entire underscript.</span>
+        <br/>Comparisons are <a data-cite="INFRA#ascii-case-insensitive">ASCII case-insensitive</a>,
+       where all matching strings are allowed as values.
        </td>
       </tr>
      </tbody>
@@ -5876,6 +5915,8 @@
    the core of overscripts that are embellished operators should stretch to cover the
    base,
    but the alignment is based on the entire overscript.</span>
+   <br/>Comparisons are <a data-cite="INFRA#ascii-case-insensitive">ASCII case-insensitive</a>,
+       where all matching strings are allowed as values.
         </td>
        </tr>
       </tbody>
@@ -6039,6 +6080,8 @@
         the core of underscripts and overscripts that are embellished operators should stretch
         to cover the base,
         but the alignment is based on the entire underscript or overscript.</span>
+        <br/>Comparisons are <a data-cite="INFRA#ascii-case-insensitive">ASCII case-insensitive</a>,
+       where all matching strings are allowed as values.
        </td>
       </tr>
      </tbody>
@@ -6349,6 +6392,8 @@
         the <code class="attribute">rowalign</code>
         value is <code class="attributevalue">baseline</code> or <code class="attributevalue">axis</code>; MathML does not specify how
         <code class="attributevalue">baseline</code> or <code class="attributevalue">axis</code> alignment should occur for other values of <code class="attribute">rowalign</code>.</span>
+        <br/>Comparisons are <a data-cite="INFRA#ascii-case-insensitive">ASCII case-insensitive</a>,
+       where all matching strings are allowed as values.
        </td>
       </tr>
  
@@ -6368,6 +6413,8 @@
         <code class="attributevalue">baseline</code> aligns the baselines of the cells;
         <code class="attributevalue">axis</code> aligns the axis of each cells.
         (See the note below about multiple values.)
+        <br/>Comparisons are <a data-cite="INFRA#ascii-case-insensitive">ASCII case-insensitive</a>,
+       where all matching strings are allowed as values.
        </td>
       </tr>
  
@@ -6385,6 +6432,8 @@
         <code class="attributevalue">center</code> centers each cells;
         <code class="attributevalue">right</code> aligns the right side of the cells.
         (See the note below about multiple values.)
+        <br/>Comparisons are <a data-cite="INFRA#ascii-case-insensitive">ASCII case-insensitive</a>,
+       where all matching strings are allowed as values.
        </td>
       </tr>
  
@@ -6428,6 +6477,8 @@
         covers the specified percentage of the entire table width.
  
         (See the note below about multiple values.)
+        <br/>Comparisons are <a data-cite="INFRA#ascii-case-insensitive">ASCII case-insensitive</a>,
+       where all matching strings are allowed as values.
        </td>
       </tr>
  
@@ -6447,7 +6498,7 @@
         linebreaking as specified in <a href="#presm_linebreaking"></a>;
         this allows the author to specify, for example, a table being full width
         of the display.
-        When the value is <code class="attributevalue">auto</code>, the MathML
+        When the value is an <a data-cite="INFRA#ascii-case-insensitive">ASCII case-insensitive</a> match of <code class="attributevalue">auto</code>, the MathML
         renderer should calculate the table width from its contents using
         whatever layout algorithm it chooses.
         Note: numbers without units were allowed in MathML 3 and treated similarly to percentage values,
@@ -6494,6 +6545,8 @@
         <code class="attributevalue">solid</code> means solid lines;
         <code class="attributevalue">dashed</code> means dashed lines (how the dashes are spaced is implementation dependent).
         (See the note below about multiple values.)
+        <br/>Comparisons are <a data-cite="INFRA#ascii-case-insensitive">ASCII case-insensitive</a>,
+       where all matching strings are allowed as values.
        </td>
       </tr>
  
@@ -6510,6 +6563,8 @@
         <code class="attributevalue">solid</code> means solid lines;
         <code class="attributevalue">dashed</code> means dashed lines (how the dashes are spaced is implementation dependent).
         (See the note below about multiple values.)
+        <br/>Comparisons are <a data-cite="INFRA#ascii-case-insensitive">ASCII case-insensitive</a>,
+       where all matching strings are allowed as values.
        </td>
       </tr>
  
@@ -6525,6 +6580,8 @@
         <code class="attributevalue">none</code> means no lines;
         <code class="attributevalue">solid</code> means solid lines;
         <code class="attributevalue">dashed</code> means dashed lines (how the dashes are spaced is implementation dependent).
+        <br/>Comparisons are <a data-cite="INFRA#ascii-case-insensitive">ASCII case-insensitive</a>,
+       where all matching strings are allowed as values.
        </td>
       </tr>
  
@@ -6697,6 +6754,8 @@
        <td colspan="2" class="attdesc">
         overrides, for this row, the vertical alignment of cells specified
         by the <a class="intref" href="#presm_mtable_attrs"><code class="attribute">rowalign</code></a> attribute on the <code class="element">mtable</code>.
+        <br/>Comparisons are <a data-cite="INFRA#ascii-case-insensitive">ASCII case-insensitive</a>,
+       where all matching strings are allowed as values.
        </td>
       </tr>
  
@@ -6710,6 +6769,8 @@
        <td colspan="2" class="attdesc">
         overrides, for this row, the horizontal alignment of cells specified
         by the <a class="intref" href="#presm_mtable_attrs"><code class="attribute">columnalign</code></a> attribute on the <code class="element">mtable</code>.
+        <br/>Comparisons are <a data-cite="INFRA#ascii-case-insensitive">ASCII case-insensitive</a>,
+       where all matching strings are allowed as values.
        </td>
       </tr>
  
@@ -6824,6 +6885,8 @@
         specifies the vertical alignment of this cell, overriding any value
         specified on the containing <code class="element">mrow</code> and <code class="element">mtable</code>.
         See the <a class="intref" href="#presm_mtable_attrs"><code class="attribute">rowalign</code></a> attribute of <code class="element">mtable</code>.
+        <br/>Comparisons are <a data-cite="INFRA#ascii-case-insensitive">ASCII case-insensitive</a>,
+       where all matching strings are allowed as values.
        </td>
       </tr>
  
@@ -6838,6 +6901,8 @@
         specifies the horizontal alignment of this cell, overriding any value
         specified on the containing <code class="element">mrow</code> and <code class="element">mtable</code>.
         See the <a class="intref" href="#presm_mtable_attrs"><code class="attribute">columnalign</code></a> attribute of <code class="element">mtable</code>.
+        <br/>Comparisons are <a data-cite="INFRA#ascii-case-insensitive">ASCII case-insensitive</a>,
+       where all matching strings are allowed as values.
        </td>
       </tr>
  
@@ -7544,6 +7609,8 @@
       specifies the vertical alignment of the <code class="element">mstack</code> with respect to its environment.
       The legal values and their meanings are the same as that for <code class="element">mtable</code>'s
       <a class="intref" href="#presm_mtable_attrs"><code class="attribute">align</code></a> attribute.
+      <br/>Comparisons are <a data-cite="INFRA#ascii-case-insensitive">ASCII case-insensitive</a>,
+       where all matching strings are allowed as values.
      </td>
     </tr>
 
@@ -7571,6 +7638,8 @@
       the right of the first number in the row;
       see <a class="intref" href="#presm_mstyle"><code class="attributevalue">decimalpoint</code></a> for a discussion
       of <code class="attributevalue">decimalpoint</code>.
+      <br/>Comparisons are <a data-cite="INFRA#ascii-case-insensitive">ASCII case-insensitive</a>,
+       where all matching strings are allowed as values.
      </td>
     </tr>
     
@@ -7590,6 +7659,8 @@
       This excess does not participate in the column width calculation, nor does it participate
       in the overall width of the <code class="element">mstack</code>.
       In these cases, authors should take care to avoid collisions between column overflows.
+      <br/>Comparisons are <a data-cite="INFRA#ascii-case-insensitive">ASCII case-insensitive</a>,
+       where all matching strings are allowed as values.
      </td>
     </tr>
     
@@ -7612,6 +7683,8 @@
       without having to figure out what values work well.
       In all cases, the spacing between columns is a fixed amount and does not vary between
       different columns.
+      <br/>Comparisons are <a data-cite="INFRA#ascii-case-insensitive">ASCII case-insensitive</a>,
+       where all matching strings are allowed as values.
      </td>
     </tr>
 
@@ -7696,7 +7769,9 @@
   <td colspan="2" class="attdesc">
    Controls the style of the long division layout.  The names are meant as a rough
    mnemonic that describes the position of the divisor and result in relation to the
-   dividend. 		
+   dividend.
+   <br/>Comparisons are <a data-cite="INFRA#ascii-case-insensitive">ASCII case-insensitive</a>,
+       where all matching strings are allowed as values.
  </td>
  </tr>
  </tbody>
@@ -8006,6 +8081,8 @@
    the associated column.
    Compass directions are used for the values; the default is to place the carry above
    the character.
+   <br/>Comparisons are <a data-cite="INFRA#ascii-case-insensitive">ASCII case-insensitive</a>,
+       where all matching strings are allowed as values.
  </td>
  </tr>
  
@@ -8025,6 +8102,8 @@
    The crossout is only applied for columns which have a corresponding
    <code class="element">mscarry</code>.
    The crossouts should be drawn using the color specified by <code class="attribute">mathcolor</code>.
+   <br/>Comparisons are <a data-cite="INFRA#ascii-case-insensitive">ASCII case-insensitive</a>,
+       where all matching strings are allowed as values.
  </td>
  </tr>
  
@@ -8095,6 +8174,8 @@
    specifies the location of the carry or borrow relative to the character in the corresponding
    column in the row below it.
    Compass directions are used for the values.
+   <br/>Comparisons are <a data-cite="INFRA#ascii-case-insensitive">ASCII case-insensitive</a>,
+       where all matching strings are allowed as values.
  </td>
  </tr>
  
@@ -8111,6 +8192,8 @@
    one or more values may be given and all values are drawn.
    If <code class="attributevalue">none</code> is given with other values, it is essentially ignored.
    The crossout should be drawn using the color specified by <code class="attribute">mathcolor</code>.
+   <br/>Comparisons are <a data-cite="INFRA#ascii-case-insensitive">ASCII case-insensitive</a>,
+       where all matching strings are allowed as values.
  </td>
  </tr>
  </tbody>
@@ -8225,6 +8308,8 @@
    of the <code class="element">msline</code> is on the baseline of the surrounding context (if any).
    (See <a href="#presm_mfrac"></a> for discussion of the thickness keywords
    <code class="attributevalue">medium</code>, <code class="attributevalue">thin</code> and <code class="attributevalue">thick</code>.)
+   <br/>Comparisons are <a data-cite="INFRA#ascii-case-insensitive">ASCII case-insensitive</a>,
+       where all matching strings are allowed as values.
  </td>
  </tr>
  </tbody>


### PR DESCRIPTION
Addresses the "enumareted string values" piece of #178 .

I haven't seen the tables rendered, there is a chance they got quite verbose. We could compress to a column with a checkmark if preferred, I tried the low-tech edit first.