### PR TITLE
a element for #555

### DIFF
--- a/src/fundamentals.html
+++ b/src/fundamentals.html
@@ -598,7 +598,7 @@
 
      <tr>
       <td colspan="2" class="attdesc">
-	Can be used to establish the element as a hyperlink to the specified <em>URI</em>.
+	Can be used to establish the element as a hyperlink to the specified <em>URI</em>. Note that this is not supported on all elements in MathML Core, but is supported on the <a href="#presm_mrow"><code class="element">a</code></a>  element.
       </td>
      </tr>
     </tbody>

--- a/src/presentation-markup.html
+++ b/src/presentation-markup.html
@@ -3799,6 +3799,23 @@
  <p>In this case, a nested <code class="element">mrow</code> is required inside
  the parentheses, since parentheses and commas, thought of as fence and
  separator <q>operators</q>, do not act together on their arguments.</p>
+
+ <p>Hyperref links that are compatible with MathML Core may be specified by using the
+ <code class="starttag">&lt;a&gt;</code> element rather than
+ <code class="starttag">&lt;mrow&gt;</code>:</p>
+<div class="example mathml mmlcore">
+  <pre>
+    &lt;a href="https://openmath.org/cd/transc1.html#arccsch"&gt;
+      &lt;mi&gt;arccsch&lt;/mi&gt;
+        &lt;mrow&gt;
+          &lt;mo&gt;(&lt;/mo&gt;
+          &lt;mi&gt;z&lt;/mi&gt;
+          &lt;mo&gt;)&lt;/mo&gt;
+        &lt;/mrow&gt;
+      &lt;/a&gt;
+ </pre>
+ </div>
+ 
  </section>
  </section>
  

--- a/src/presentation-markup.html
+++ b/src/presentation-markup.html
@@ -3587,12 +3587,15 @@
  
   <section>
    <h4 id="presm_mrow">Horizontally Group Sub-Expressions
- <a class="coreyes" href="https://w3c.github.io/mathml-core/spec.html#dfn-mrow"><code class="defn starttag">&lt;mrow&gt;</code></a></h4>
+     <a class="coreyes" href="https://w3c.github.io/mathml-core/spec.html#dfn-mrow"><code class="defn starttag">&lt;mrow&gt;</code></a>,
+     <a class="coreyes" href="https://w3c.github.io/mathml-core/spec.html#dfn-a"><code class="defn starttag">&lt;a&gt;</code></a>
+   </h4>
  
  <section>
  <h5 id="presm_genlayout_desc">Description</h5>
  
- <p>An <code class="element">mrow</code> element is used to group together any
+ <p>An <code class="element">mrow</code> or <code class="element">a</code>
+   element is used to group together any
  number of sub-expressions, usually consisting of one or more <code class="element">mo</code> elements acting as <q>operators</q> on one
  or more other expressions that are their <q>operands</q>.</p>
  
@@ -3625,6 +3628,12 @@
  although the control of linebreaking is effected through attributes
  on other elements (see <a href="#presm_linebreaking"></a>).
  </p>
+
+ <p>In MathML 4 <code class="element">mrow</code> and
+ <code class="element">a</code> have identical behavior, however
+ <code class="element">a</code>has been added for compatibility with MathML
+ Core. MathML Core only supprts the <code class="attname">href</code>
+ attribute on the <code class="element">a</code> element.</p>
  
  </section>
  


### PR DESCRIPTION
For issue #555 This adds `<a>` as an alias for `<mrow>` in mathml full (with a reference to `<a href` working in mathml core 

matching PR will be needed in mathML-Core and MathML-Schema