### PR TITLE
A element further adjustments

### DIFF
--- a/src/presentation-markup.html
+++ b/src/presentation-markup.html
@@ -1291,7 +1291,7 @@
      In a Web Platform Context  it is recommended that the HTML <code class="element">img</code>
      element is used. This is allowed in token elements when MathML is embedded in (X)HTML.
      </p>
-     <p>For existing MathML using <code class="element">mglyph</code> a <a href="https://w3c.github.io/mathml-polyfills/">Javascript polyfill</a>
+     <p>For existing MathML using <code class="element">mglyph</code> a <a href="https://w3c.github.io/mathml-polyfills/">JavaScript polyfill</a>
      is provided for Web documents that implements <code class="element">mglyph</code> using <code class="element">img</code>. </p>
     </div>
     

--- a/src/presentation-markup.html
+++ b/src/presentation-markup.html
@@ -3629,10 +3629,10 @@
  on other elements (see <a href="#presm_linebreaking"></a>).
  </p>
 
- <p>In MathML 4 <code class="element">mrow</code> and
+ <p>In MathML 4, <code class="element">mrow</code> and
  <code class="element">a</code> have identical behavior, however
- <code class="element">a</code>has been added for compatibility with MathML
- Core. MathML Core only supprts the <code class="attname">href</code>
+ <code class="element">a</code> has been added for compatibility with MathML
+ Core. MathML Core only supports the <code class="attname">href</code>
  attribute on the <code class="element">a</code> element.</p>
  
  </section>
@@ -3640,37 +3640,11 @@
  <section>
   <h5 id="presm_genlayout_att">Attributes</h5>
  
-  <p><code class="element">mrow</code> elements accept the attribute listed below in addition to
-  those listed in <a href="#presm_presatt"></a>.</p>
- 
-  <table class="attributes data">
- 
-   <thead>
- 
-    <tr>
-     <td>Name</td>
- <td>values</td>
- <td>default</td>
- </tr>
- </thead>
- 
- <tbody>
- 
-  <tr>
- <td rowspan="2" class="attname"><a class="coreyes" href="https://w3c.github.io/mathml-core/spec.html#dfn-dir">dir</a></td>
- <td>"ltr" | "rtl"</td>
- <td><em>inherited</em></td>
- </tr>
- 
- <tr>
-  <td colspan="2" class="attdesc">
-   specifies the overall directionality <code>ltr</code> (Left To Right) or
-   <code>rtl</code> (Right To Left) to use to layout the children of the row.
-   See <a href="#presm_bidi_math"></a> for further discussion.
- </td>
- </tr>
- </tbody>
- </table>
+  <p>The <code class="element">mrow</code> and <code class="element">a</code>
+  elements accept the attributes specified on the
+  <a href="https://html.spec.whatwg.org/#the-a-element">corresponding
+  element in HTML</a> in addition to those listed in <a
+  href="#presm_presatt"></a>.</p>
  
  </section>
  

--- a/src/world-interactions.html
+++ b/src/world-interactions.html
@@ -1038,9 +1038,8 @@
   <section>
    <h4 id="interf_link">Linking</h4>
 
-   <p>In MathML 3, an element is designated as a link by the presence of
-   the <code class="attribute">href</code> attribute.  MathML has no element that corresponds
-   to the HTML/XHTML anchor element <code class="element" data-namespace="xhtml">a</code>. </p>
+   <p>In MathML, an element is designated as a link by the presence of
+   the <code class="attribute">href</code> attribute.</p>
 
    <p>MathML allows the <code class="attribute">href</code> attribute on all
    elements.
@@ -1076,26 +1075,20 @@
     </tbody>
    </table>
 
+   <p>Note that [[MathML-Core]] does not support the use of
+   <code class="attribute">href</code> attribute on all
+   elements and  a specific element
+   <code class="element">a</code> has been introduced for this purpose.
+   MathML generators aiming for compatibility with MathML-Core may
+   restrict use of the <code class="attribute">href</code> attribute
+   to <code class="element">a</code>  or to make use of the provided 
+   <a href="https://w3c.github.io/mathml-polyfills/">JavaScript polyfill</a>.</p>
+   
    <p>For compound document formats that support linking mechanisms, the
    <code class="attribute">id</code> attribute should
    be used to specify the location for a link into a MathML expression.  The
    <code class="attribute">id</code> attribute is allowed on all MathML elements, and its value
    must be unique within a document, making it ideal for this purpose.</p>
-
-   <p>Note that MathML 2 has no direct support for linking; it refers to
-   the W3C Recommendation "XML Linking Language" [[?XLink]] in
-   defining links in compound document contexts by using an <code class="attribute">xlink:href</code> attribute.
-   As mentioned above, MathML 3 adds an <code class="attribute">href</code>
-   attribute for linking so that <code class="attribute">xlink:href</code> is no longer needed.
-   However, <code class="attribute">xlink:href</code> is still allowed because MathML permits the use of attributes
-   from non-MathML namespaces. It is recommended that new compound document
-   formats use the MathML 3 <code class="attribute">href</code> attribute for linking. When user agents
-   encounter MathML elements with both <code class="attribute">href</code> and <code class="attribute">xlink:href</code> attributes, the
-   <code class="attribute">href</code> attribute should take precedence. To support backward
-   compatibility, user agents that implement XML Linking
-   in compound documents containing MathML 2 should continue to support
-   the use of the <code class="attribute">xlink:href</code> attribute in addition to supporting the <code class="attribute">href</code> attribute.
-   </p>
 
   </section>
 


### PR DESCRIPTION
This 

* deletes the description of `dir` as an additonal mrow-specific attribute (as it is already allowed on all presentation elements, inherited from mathml-core)

* updates the linking section in chapter 7 (which was explicitly describing MathML **3**)

* documents `<mrow>`  and `<a>` as taking attributes such as `target=_blank` from HTML `<a>`

(this last part may need some adjustment depending on how exactly `<a>` gets added to mathml-core, but this at least gets the current drafts aligned.



