### PR TITLE
Proofread spec text

### DIFF
--- a/src/accessibility.html
+++ b/src/accessibility.html
@@ -112,7 +112,7 @@ classroom for young students.</p>
 <p>Braille output. The tactile rendering of mathematical expressions
 in braille is a very important use case. For someone who is blind,
 interpreting mathematics through auditory rendering alone is a
-cognitive taxing experience except for the most basic expressions. And
+cognitively taxing experience except for the most basic expressions. And
 for a deafblind user, auditory renderings are completely
 inaccessible. Several math braille codes are in common use globally,
 such as the Nemeth braille code, UEB Technical, German braille
@@ -147,7 +147,7 @@ for individuals who are deaf or hard of hearing would be the ability
 to provide input to automated signing avatars. Automated signing
 avatar technology which generates American Sign Language has already
 been applied to elementary level mathematics <span class="note">add citation</span>. Sign
-languages vary by county (and sometimes locality) and are not simply
+languages vary by country (and sometimes locality) and are not simply
 "word to sign" translations, as sign language has its own grammar, so
 being able to access the underlying tree structure of mathematical
 expressions as can be done with MathML will provide the potential for
@@ -225,7 +225,7 @@ standardized assessments). However, there are numerous limitations to
 this method. For instance, the entire spoken text of the expression
 must be given in the tag, even if the author is only concerned about
 one small portion. Further, <code class="attribute">alttext</code> is
-limited to plain text, so speech queues such as pausing and pitch
+limited to plain text, so speech cues such as pausing and pitch
 changes cannot be included for passing on to speech engines. Also, the
 <code class="attribute">alttext</code> attribute has no direct linkage
 to the MathML tree, so there will be no way to handle synchronized
@@ -238,7 +238,7 @@ responsible for MathML accessibility in their product. The goal of
 this specification is to maximize the accessibility of MathML content
 by ensuring each assistive technology receives MathML content with the
 roles, states, and properties it expects. The placing of ARIA labels
-and <code>aria-labeledby</code> is not appropriate in MathML because this will override
+and <code>aria-labelledby</code> is not appropriate in MathML because this will override
 braille generation.</p>
 </section>
 
@@ -276,7 +276,7 @@ consistent throughout the page.</p>
    <section>
     <h5 id="acc_intent">Use <code>intent</code> and <code>arg</code> attributes</h5>
 
-<p>MathML's <code>intent</code> and <code>arg</code> attributes has
+<p>MathML's <code>intent</code> and <code>arg</code> attributes have
 been developed to reduce notational ambiguity which cannot be reliably
 resolved by assistive technology. This also includes blanks and units,
 which are covered by the Intent attribute.</p>

--- a/src/changes.html
+++ b/src/changes.html
@@ -41,7 +41,7 @@
     The `mathml4-legacy` schema makes these valid if needed for legacy applications.</li>
 
     <li>Remove the <code class="attribute">other</code> attribute.
-    This have been deprecated
+    This had been deprecated
     since MathML&#160;2.
     The `mathml4-legacy` schema makes this valid if needed for legacy applications.</li>
 
@@ -85,10 +85,10 @@
     <code class="element">mglyph</code> which is still retained to include images in MathML.
     </li>
     <li>The value `indentingnewline` is no longer valid for <code
-    class="element">mspace</code> (it was equivalent  to `newline`).
+    class="element">mspace</code> (it was equivalent to `newline`).
     </li>
     <li>In MathML table rows and cells must be explicitly marked
-    wih <code class="element">mtr</code> and <code
+    with <code class="element">mtr</code> and <code
     class="element">mtd</code>. The [[?MathML1]] required that an
     implementation infer the row markup if it was omitted.
     </li>
@@ -110,7 +110,7 @@
     are no longer specified. They are removed from the default schema but valid in
     the <a href="#parsing_rnc_legacy">Legacy Schema</a>.</li>
 
-    <li>To align with MathML-Core, the special extended syntax for  <code class="element">mpadded</code> length attributes 
+    <li>To align with MathML-Core, the special extended syntax for <code class="element">mpadded</code> length attributes 
       <code>( "+" | "-" )?
       <em>unsigned-number</em>
       ( ("%" <em>pseudo-unit</em>?)

--- a/src/changes.html
+++ b/src/changes.html
@@ -41,7 +41,7 @@
     The `mathml4-legacy` schema makes these valid if needed for legacy applications.</li>
 
     <li>Remove the <code class="attribute">other</code> attribute.
-    This had been deprecated
+    This has been deprecated
     since MathML&#160;2.
     The `mathml4-legacy` schema makes this valid if needed for legacy applications.</li>
 

--- a/src/character-set.html
+++ b/src/character-set.html
@@ -281,7 +281,7 @@
    are already shrunk and raised from the baseline.
    </p>
 
-   <p>The second reason that explicit script markup is preferrable to
+   <p>The second reason that explicit script markup is preferable to
    juxtaposition of characters is that it generally better reflects the
    intended mathematical structure. For example,</p>
 
@@ -310,7 +310,7 @@
    </div>
 
    <p>While the first form may, in some rare situations, legitimately be used
-   to distinguish a multi-character identifer named x' from the
+   to distinguish a multi-character identifier named x' from the
    derivative of a function x, such forms should generally be avoided.
    Authoring and validation tools are encouraged to generate the
    recommended script markup:</p>

--- a/src/conformance.html
+++ b/src/conformance.html
@@ -21,7 +21,7 @@
   MathML expressions, and rendering engines that produce visual, aural,
   or tactile representations of mathematical notation.  What it
   means to support MathML varies widely between applications.  For
-  example, the issues that arise with a  validating
+  example, the issues that arise with a validating
   parser are very different from those for an equation
   editor.</p>
 
@@ -77,7 +77,7 @@
      preserve MathML equivalence. Two MathML expressions are
      &#x201c;equivalent&#x201d; if and only if both expressions have the
      same interpretation (as stated by the MathML
-     Schema and  specification)
+     Schema and specification)
      under any relevant circumstances, by any MathML processor. Equivalence on an
      element-by-element basis is discussed elsewhere in this document.</p>
 
@@ -165,7 +165,7 @@
     <p>MathML 4.0 contains a number of features of earlier MathML
     which are now deprecated.  The following points define what it means for a
     feature to be deprecated, and clarify the relation between
-    deprecated features and  current MathML conformance.</p>
+    deprecated features and current MathML conformance.</p>
 
     <ol>
 
@@ -278,7 +278,7 @@
    attribute obsolete.  In MathML 2.0, the <code class="attribute">other</code> attribute is
    <a class="intref" href="#interf_deprec">deprecated</a> in favor of the use of
    namespace prefixes to identify non-MathML attributes.  The
-   <code class="attribute">other</code> attribute has been removed in MathML 4.0. although it
+   <code class="attribute">other</code> attribute has been removed in MathML 4.0, although it
    is still valid (with no defined behavior) in the mathml4-legacy schema.</p>
 
    <p>For example, in MathML 1.0, it was recommended that if additional information
@@ -317,7 +317,7 @@
       <section>
       <h3 id="privacy">Privacy Considerations</h3>
       <p>Web platform implementations of MathML should implement [[MathML-Core]],
-	and so the <a href="https://www.w3.org/TR/mathml-core/#privacy-considerations">Privacy Considerations</a>  specified there apply.</p>
+	and so the <a href="https://www.w3.org/TR/mathml-core/#privacy-considerations">Privacy Considerations</a> specified there apply.</p>
     </section>
     
 

--- a/src/contributors.html
+++ b/src/contributors.html
@@ -46,7 +46,7 @@
    <span title="W3C Invited Experts: University of Marrakesh, Morocco">Azzeddine Lazrek</span>,
    <span title="DAISY Consortium">Dennis Leas</span>,
    <span title="German Research Center for Artificial Intelligence (DFKI) Gmbh, GER">Paul Libbrecht</span>,
-   <span title="University of Edinburgh, Edinburg, UK">Manolis Mavrikis</span>,
+   <span title="University of Edinburgh, Edinburgh, UK">Manolis Mavrikis</span>,
    <span title="National Institute of Standards and Technology (NIST), Gaithersburg MD, USA">Bruce Miller</span>,
    <span title="Design Science Inc., Long Beach CA, USA">Robert Miner</span>,
    <span title="The Open University, UK">Chris Rowley</span>,
@@ -136,7 +136,7 @@
    <span title="IBM Almaden, Palo Alto CA, USA (earlier with Adobe Inc., Mountain View CA, USA)">T.V. Raman</span>,
    <span title="Microsoft, Redmond WA, USA">Murray Sargent III</span>,
    <span title="Wolfram Research Inc., Champaign IL, USA">Neil Soiffer</span>,
-   <span title="Universit&#xe1; di Bologna, Bologna, IT">Irene Schena</span>,
+   <span title="Universit&#xe0; di Bologna, Bologna, IT">Irene Schena</span>,
    <span title="Design Science Inc., Long Beach CA, USA">Paul Topping</span>,
    <span title="University of Western Ontario, London ON, CAN">Stephen Watt</span>
   </blockquote>

--- a/src/fundamentals.html
+++ b/src/fundamentals.html
@@ -19,9 +19,9 @@
    and how they may be contained within each other,
    as well as additional syntactic rules for the values of attributes.
    These rules are defined by this specification,
-   and formalized by a RelaxNG schema  [[RELAXNG-SCHEMA]] in <a href="#parsing"></a>.
+   and formalized by a RelaxNG schema [[RELAXNG-SCHEMA]] in <a href="#parsing"></a>.
    Derived schema in other formats, DTD (Document Type Definition)
-   and  XML Schema [[XMLSchemas]] are also provided.
+   and XML Schema [[XMLSchemas]] are also provided.
    </p>
 
    <p>MathML's character set consists of any
@@ -140,8 +140,8 @@
    <section>
     <h5 id="fund_syntax_notation">Syntax notation used in the MathML specification</h5>
 
-    <p>To  describe  the  MathML-specific  syntax  of
-    attribute values, the  following conventions and notations are
+    <p>To describe the MathML-specific syntax of
+    attribute values, the following conventions and notations are
     used for most attributes in the present document.</p>
 
 
@@ -245,7 +245,7 @@
        of any characters not allowed in URI using %HH encoding where HH are the byte value
        in hexadecimal.
        This ensures that such an attribute value may be interpreted as an IRI,
-       or more generally a LEIRI; see  [[IRI]].</td>
+       or more generally a LEIRI; see [[IRI]].</td>
       </tr>
 
       <tr>
@@ -601,7 +601,7 @@
 
      <tr>
       <td colspan="2" class="attdesc">
-	Can be used to establish the element as a hyperlink to the specified <em>URI</em>. Note that this is not supported on all elements in MathML Core, but is supported on the <a href="#presm_mrow"><code class="element">a</code></a>  element.
+	Can be used to establish the element as a hyperlink to the specified <em>URI</em>. Note that this is not supported on all elements in MathML Core, but is supported on the <a href="#presm_mrow"><code class="element">a</code></a> element.
       </td>
      </tr>
     </tbody>
@@ -665,7 +665,7 @@
    <h4 id="fund_collapse">Collapsing Whitespace in Input</h4>
 
    <p>In MathML, as in XML, <q>whitespace</q> means simple spaces,
-   tabs, newlines, or carriage returns, i.e.,  characters with hexadecimal
+   tabs, newlines, or carriage returns, i.e., characters with hexadecimal
    Unicode codes U+0020, U+0009, U+000A, or
    U+000D, respectively; see also the discussion of whitespace in Section 2.3 of
    [[XML]].</p>
@@ -674,7 +674,7 @@
    Non-whitespace characters are not allowed there. Whitespace occurring
    within the content of token elements, except for <a class="intref" href="#contm_cs"><code class="starttag">&lt;cs&gt;</code></a>, is normalized as follows. All whitespace at the beginning and end of the content is
    removed, and whitespace internal to content of the element is
-   collapsed canonically, i.e.,  each sequence of 1 or more
+   collapsed canonically, i.e., each sequence of 1 or more
    whitespace characters is replaced with one space character (U+0020, sometimes
    called a blank character).</p>
 
@@ -755,7 +755,7 @@
   <section>
    <h4 id="interf_toplevel_atts">Attributes</h4>
 
-   <p>The <code class="element">math</code> element accepts any of the common presentation attributess specified in
+   <p>The <code class="element">math</code> element accepts any of the common presentation attributes specified in
    <a href="#presm_presatt">Mathematics attributes common to presentation elements</a>,
    along with the common attributes
    specified in <a href="#fund_globatt"></a>.
@@ -842,7 +842,7 @@
 
      <tr>
       <td colspan="2" class="attdesc">
-       specifies the preferred handing in cases where an expression is too long to
+       specifies the preferred handling in cases where an expression is too long to
        fit in the allowed width. See the discussion below.
        <br/>Comparisons are <a data-cite="INFRA#ascii-case-insensitive">ASCII case-insensitive</a>,
        where all matching strings are allowed as values.
@@ -885,7 +885,7 @@
       <td colspan="2" class="attdesc">
        specifies the height to display <code class="attribute">altimg</code>, scaling the image if necessary;
        if only one of the attributes <code class="attribute">altimg-width</code> and <code class="attribute">altimg-height</code>
-       are given, the scaling should preserve the image's aspect ratio;
+       is given, the scaling should preserve the image's aspect ratio;
        if neither attribute is given, the image should be shown at its natural size.
       </td>
      </tr>
@@ -903,7 +903,7 @@
        A positive value of <code class="attribute">altimg-valign</code> shifts the bottom of the image above the
        current baseline, while a negative value lowers it.
        The keyword "top" aligns the top of the image with the top of adjacent inline material;
-       "center" aligns the middle of the image to the middle of adjacent material;
+       "middle" aligns the middle of the image to the middle of adjacent material;
        "bottom" aligns the bottom of the image to the bottom of adjacent material
        (not necessarily the baseline). This attribute only has effect
        when <code class="attribute">display</code>=<code class="attributevalue">inline</code>.

--- a/src/mixing.html
+++ b/src/mixing.html
@@ -620,7 +620,7 @@
     <ul>
 
      <li>
-      <p>If the <code class="element">annotation-xml</code> has an <code class="attribute">encoding</code> attribute that is (ignoring case differences) <code class="attributevalue">text/html</code> or <code class="attributevalue">annotation/xhtml+xml</code> then the content  is parsed as HTML and placed (initially) in the HTML namespace.</p>
+      <p>If the <code class="element">annotation-xml</code> has an <code class="attribute">encoding</code> attribute that is (ignoring case differences) <code class="attributevalue">text/html</code> or <code class="attributevalue">application/xhtml+xml</code> then the content is parsed as HTML and placed (initially) in the HTML namespace.</p>
      </li>
 
      <li>

--- a/src/operator-dict.html
+++ b/src/operator-dict.html
@@ -59,7 +59,7 @@
    <code>&lt;mo&gt;&amp;InvisibleTimes;&lt;/mo&gt;</code>, the total spacing
    should be greater than zero when both operands (or the nearest tokens on
    either side, if on the baseline) are identifiers displayed in a non-slanted
-   font (i.e.. under the suggested rules, when both operands are
+   font (i.e., under the suggested rules, when both operands are
   multi-character identifiers).</p>
 
   <p>Some renderers may wish to use no spacing for most operators

--- a/src/presentation-markup.html
+++ b/src/presentation-markup.html
@@ -190,7 +190,7 @@
      </div>
  
      <p>This feature allows MathML data not to contain (and its authors to
-     leave out)  many <code class="element">mrow</code> elements that would otherwise be
+     leave out) many <code class="element">mrow</code> elements that would otherwise be
      necessary.</p>
     </section>
  
@@ -623,7 +623,7 @@
     <h5 id="presm_control_linebreaks">Control of Linebreaks</h5>
  
     <p>MathML provides support for both automatic and manual (forced)
-    linebreaking of  expressions to break excessively long
+    linebreaking of expressions to break excessively long
     expressions into several lines.
     All such linebreaks take place within <code class="element">mrow</code>
     (including inferred <code class="element">mrow</code>; see <a href="#presm_inferredmrow"></a>)
@@ -789,7 +789,7 @@
  
       <tr>
        <td><a class="intref" href="#presm_mo"><code class="element">mo</code></a></td>
-       <td>operator, fence, or  separator</td>
+       <td>operator, fence, or separator</td>
       </tr>
  
       <tr>
@@ -1031,7 +1031,7 @@
    href="https://www.w3.org/TR/mathml-core/#global-attributes">Global
    Attributes</a> specified by [[MathML-Core]].</p>
  
-   <p>These attributes include the following  attributes that are primarily intended for visual media.
+   <p>These attributes include the following attributes that are primarily intended for visual media.
    They are not expected to affect the intended semantics of displayed
    expressions. The first two are for use in highlighting or drawing attention
    to the affected subexpressions.  For example, a red "x" is not assumed
@@ -1293,7 +1293,7 @@
 
     <div id="notcore-mglyph" class="note" title="mglyph is not in MathML-Core">
      <p><code class="element">mglyph</code> is not supported in [[MathML-Core]].
-     In a Web Platform Context  it is recommended that the HTML <code class="element">img</code>
+     In a Web Platform Context it is recommended that the HTML <code class="element">img</code>
      element is used. This is allowed in token elements when MathML is embedded in (X)HTML.
      </p>
      <p>For existing MathML using <code class="element">mglyph</code> a <a href="https://w3c.github.io/mathml-polyfills/">JavaScript polyfill</a>
@@ -1990,7 +1990,7 @@
     with additional spacing around the element determined by its attributes and
     further described below.
     Renderers without access to complete fonts for the MathML character
-    set may choose  to render an <code class="element">mo</code> element as
+    set may choose to render an <code class="element">mo</code> element as
     <span>not</span> precisely the characters in its content in some cases. For example,
     <code>&lt;mo&gt; &#x2264; &lt;/mo&gt;</code> might be rendered as
     <code>&lt;=</code> to a terminal.  However, as a general rule,
@@ -2302,7 +2302,7 @@
    (but possibly indented);
    <code class="attributevalue">after</code> causes it to appear at the end of the line before the break.
    <code class="attributevalue">duplicate</code> places the operator at both positions.
-   <code class="attributevalue">infixlinebreakstyle</code> uses the value  that has been specified for
+   <code class="attributevalue">infixlinebreakstyle</code> uses the value that has been specified for
    infix operators; this value (one of <code class="attributevalue">before</code>,
    <code class="attributevalue">after</code> or <code class="attributevalue">duplicate</code>) can be specified by
    the application or bound by <a class="intref" href="#presm_mstyle"><code class="element">mstyle</code></a>
@@ -3644,7 +3644,7 @@
  they are contained in.</p>
  
  <p>MathML provides support for both automatic and manual
- linebreaking of  expressions (that is, to break excessively long
+ linebreaking of expressions (that is, to break excessively long
  expressions into several lines). All such linebreaks take place
  within <code class="element">mrow</code>s, whether they are explicitly marked up
  in the document, or inferred (see <a href="#presm_inferredmrow"></a>),
@@ -3930,10 +3930,10 @@
  </table>
  
  <p>Thicker lines (e.g. <code class="attribute">linethickness</code>="thick") might be used with nested fractions;
- a value of "0" renders without the bar such as for  binomial coefficients.</p>
+ a value of "0" renders without the bar such as for binomial coefficients.</p>
  
  <p>
-  In a RTL directionality context,  the numerator leads (on the right),
+  In a RTL directionality context, the numerator leads (on the right),
   the denominator follows (on the left) and the diagonal line slants upwards going from
   right to left<span> (see <a href="#presm_bidi_math"></a> for clarification)</span>.
   Although this format is an established convention, it is not universally
@@ -4187,7 +4187,7 @@
  <code class="element">mstyle</code> in any manner affect a <span>descendant</span> element
  in the <code class="element">mstyle</code>'s content only if that attribute is
  not given a value <span>by the descendant element</span>. On any element for
- which the attribute is set explicitly, the value specified  overrides the inherited
+ which the attribute is set explicitly, the value specified overrides the inherited
  value. The only exception to this
  rule is when the <span>attribute</span> value
  is documented as
@@ -6156,7 +6156,7 @@
     <p>This element allows the representation of any number of vertically-aligned pairs of
     subscripts
     and superscripts, attached to one base expression. It supports both
-    postscripts  and prescripts.
+    postscripts and prescripts.
     Missing scripts must be represented by a valid empty element denoting the empty subterm,
     such as <code class="emptytag">&lt;mrow/&gt;</code>.
     (The element <code class="defn emptytag">&lt;none/&gt;</code> was used in earlier MathML releases, but was equivalent
@@ -6865,7 +6865,7 @@
       <tr>
        <td colspan="2" class="attdesc">
         causes the cell to be treated as if it occupied the number of columns specified.
-        The following <code class="attributevalue">rowspan</code>-1 <code class="element">mtd</code>s must be omitted.
+        The following <code class="attributevalue">columnspan</code>-1 <code class="element">mtd</code>s must be omitted.
         The interpretation corresponds with the similar attributes for HTML tables.
        </td>
       </tr>
@@ -6966,7 +6966,7 @@
        <code class="element">malignmark</code> is the point of alignment for that group.
     </p>
 
-    <p>If <code class="element">maligngroup</code> or <code class="element">maligngroup</code> occurs outside of an
+    <p>If <code class="element">maligngroup</code> or <code class="element">malignmark</code> occurs outside of an
         <code class="element">mtable</code>, they are rendered with zero width.
     </p>
 
@@ -7073,7 +7073,7 @@
     <p>When an <code class="element">malignmark</code> element is provided within an
     alignment group, it should only occur within the elements allowed for <code class="element">maligngroup</code>
     (see <a href="#presm_specify_align_group"></a>).
-    If there should be at most one <code class="element">malignmark</code> element
+    There should be at most one <code class="element">malignmark</code> element
     in an alignment group.</p>
   </section>
  
@@ -7081,7 +7081,7 @@
  <section>
  <h5 id="presm_alignment_algo">Alignment algorithm</h5>
 
- <p>Alignments marked wth <code class="element">maligngroup</code>
+ <p>Alignments marked with <code class="element">maligngroup</code>
  may be converted to an equivalent <code class="element">mtable</code>
  that does not use <code class="element">maligngroup</code>, but uses
  additional table columns.
@@ -7562,7 +7562,7 @@
  <p>a notation that is commonly used in France and elsewhere</p>
  </dd>
  
- <dt><code class="attributevalue">mediumrightright</code></dt>
+ <dt><code class="attributevalue">mediumstackedrightright</code></dt>
  <dd>
  <p>a notation that is commonly used in Russia and elsewhere</p>
  </dd>
@@ -8446,7 +8446,7 @@
   For the last example, the only difference from the other examples besides a different
   value for
   <code class="attribute">longdivstyle</code> is that Arabic numerals have been used in place of Latin numerals,
- as shown  below.</p>
+ as shown below.</p>
  
  <div class="example mathml mml4p">
   <pre>

--- a/src/world-interactions.html
+++ b/src/world-interactions.html
@@ -72,7 +72,7 @@
 
    <p>HTML does not allow arbitrary namespaces, but has built-in knowledge of the MathML
    namespace.
-   The <code class="element">math</code> element and its descendants will be placed in the  <code>http://www.w3.org/1998/Math/MathML</code>
+   The <code class="element">math</code> element and its descendants will be placed in the <code>http://www.w3.org/1998/Math/MathML</code>
    namespace by the HTML parser, and will appear to applications as if the input had
    been XHTML with the namespace declared
    as in the previous section. See <a href="#interf_html"></a> for detailed rules of the HTML parser's handling of MathML.</p>
@@ -933,7 +933,7 @@
   </section>
 
   <section>
-   <h4 id="interf_nonxml">Mixing MathML and  non-XML contexts</h4>
+   <h4 id="interf_nonxml">Mixing MathML and non-XML contexts</h4>
 
    <p>There may be non-XML vocabularies which require markup for mathematical expressions,
    where it makes sense to reference this specification. HTML is an important example
@@ -972,7 +972,7 @@
    HTML parser
    distinguishes parsing from validation; some input, even if it renders correctly, is
    classed as a
-   <em>parse error</em>  which may be reported by validators (but typically is not reported by
+   <em>parse error</em> which may be reported by validators (but typically is not reported by
    rendering systems).</p>
 
    <p> The main differences that affect MathML usage
@@ -993,7 +993,7 @@
      <p>HTML does not support namespaces other than the three built in ones for HTML, MathML
      and SVG, and
      does not support namespace prefixes. Thus you cannot use a prefix form like <code>&lt;mml:math
-     xmlns:mml="http://www.w3.org/1998/Math/MathML"&gt;</code> and while you may use  <code>&lt;math
+     xmlns:mml="http://www.w3.org/1998/Math/MathML"&gt;</code> and while you may use <code>&lt;math
      xmlns="http://www.w3.org/1998/Math/MathML"&gt;</code>, the namespace declaration is essentially ignored
      and the input is treated as <code>&lt;math&gt;</code>. In either case the <code class="element">math</code> element and its
      descendants are placed in the MathML namespace. As noted in <a href="#mixing"></a> the lack of
@@ -1016,7 +1016,7 @@
     <li>
      <p>Unless inside the token elements <code class="starttag">&lt;mtext&gt;</code>, <code class="starttag">&lt;mo&gt;</code>, <code class="starttag">&lt;mn&gt;</code>, <code class="starttag">&lt;mi&gt;</code>,
      <code class="starttag">&lt;ms&gt;</code>, or inside an <code class="starttag">&lt;annotation-xml&gt;</code> with <code class="attribute">encoding</code> attribute
-     <code class="attributevalue">text/html</code> or <code class="attributevalue">annotation/xhtml+xml</code>, the presence of an HTML element
+     <code class="attributevalue">text/html</code> or <code class="attributevalue">application/xhtml+xml</code>, the presence of an HTML element
      will <em>terminate</em> the math expression by closing all open MathML elements, so
      that the HTML element is interpreted as being in the outer HTML context. Any following
      MathML
@@ -1077,11 +1077,11 @@
 
    <p>Note that [[MathML-Core]] does not support the use of
    <code class="attribute">href</code> attribute on all
-   elements and  a specific element
+   elements and a specific element
    <code class="element">a</code> has been introduced for this purpose.
    MathML generators aiming for compatibility with MathML-Core may
    restrict use of the <code class="attribute">href</code> attribute
-   to <code class="element">a</code>  or to make use of the provided 
+   to <code class="element">a</code> or to make use of the provided 
    <a href="https://w3c.github.io/mathml-polyfills/">JavaScript polyfill</a>.</p>
    
    <p>For compound document formats that support linking mechanisms, the
@@ -1143,7 +1143,7 @@
    uses the
    XHTML <code class="element" data-namespace="xhtml">img</code> element embedded as an XHTML fragment.
    In this situation, a MathML processor can use any of these
-   representations for display,  perhaps producing a graphical format
+   representations for display, perhaps producing a graphical format
    such as the image below.</p>
 
    <blockquote>
@@ -1151,7 +1151,7 @@
    </blockquote>
 
    <p>Note that the semantics representation of this example is given
-   in  MathML-Content markup, as the first child of the
+   in MathML-Content markup, as the first child of the
    <code class="element">semantics</code> element.  In this regard, it is the
    representation most analogous to the <code class="attribute">alt</code> attribute of the
    <code class="element" data-namespace="xhtml">img</code> element in XHTML, and would likely be
@@ -1218,7 +1218,7 @@
 
   <p>MathML 3.0 does not specify how a user agent should process style
   information, because there are many non-CSS MathML environments, and
-  because different users agents and renderers have widely varying
+  because different user agents and renderers have widely varying
   degrees of access to CSS information.</p>
 
   <section>


### PR DESCRIPTION
Proofread rest-of-spec (skipped Chapter 5 and all Content MathML text)

Mostly managed by Claude Opus 4.6 "heavy effort".

Whitespace-free diff should be available at:
https://github.com/w3c/mathml/pull/571/changes?w=1